### PR TITLE
Remove .npmrc 

### DIFF
--- a/examples/hello/.npmrc
+++ b/examples/hello/.npmrc
@@ -1,2 +1,0 @@
-@dbos-inc:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
The "Hello, World!" example created by `npx operon init` now pulls from our [public npm repository](https://www.npmjs.com/package/@dbos-inc/operon).