### PR TITLE
Support entrypoint CLI/local runtime config option

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,7 +13,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
   },
   root: true,
-  ignorePatterns: ["dist/", "knexfile.ts", "**/migrations/*"],
+  ignorePatterns: ["dist/", "knexfile.ts", "**/migrations/*", "examples/"],
   overrides: [
     {
       files: ["*.js"],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,17 +5,11 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
+            "command": "npx operon start",
             "name": "Launch Example",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
             "preLaunchTask": "build example",
-            "program": "${workspaceFolder}/examples/hello/dist/app.js",
-            "outFiles": [
-                "${workspaceFolder}/**/*.js"
-            ],
+            "request": "launch",
+            "type": "node-terminal",
             "cwd": "${workspaceFolder}/examples/hello",
             "envFile": "${workspaceFolder}/examples/hello/.env"
         }

--- a/examples/hello/tsconfig.json
+++ b/examples/hello/tsconfig.json
@@ -15,7 +15,10 @@
     "strict": true,                                      /* Enable all strict type-checking options. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-    "include": [                                         /* Specifies an array of filenames or patterns to include in the program. */
-      "src",
-    ]
+  "include": [                                           /* Specifies an array of filenames or patterns to include in the program. */
+    "src",
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
 }

--- a/src/operon-runtime/cli.ts
+++ b/src/operon-runtime/cli.ts
@@ -22,6 +22,7 @@ export interface OperonCLIStartOptions {
   port?: number,
   loglevel?: string,
   configfile?: string,
+  entrypoint?: string,
 }
 
 program
@@ -30,6 +31,7 @@ program
   .option('-p, --port <number>', 'Specify the port number')
   .option('-l, --loglevel <string>', 'Specify Operon log level')
   .option('-c, --configfile <string>', 'Specify the Operon config file path', operonConfigFilePath)
+  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
   .action(async (options: OperonCLIStartOptions) => {
     const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(options);
     const runtime = new OperonRuntime(operonConfig, runtimeConfig);

--- a/src/operon-runtime/config.ts
+++ b/src/operon-runtime/config.ts
@@ -121,6 +121,7 @@ export function parseConfigFile(cliOptions?: OperonCLIStartOptions): [OperonConf
   /* Build final runtime Configuration */
   /*************************************/
   const localRuntimeConfig: OperonRuntimeConfig = {
+    entrypoint: cliOptions?.entrypoint || configFile.localRuntimeConfig?.entrypoint,
     port: cliOptions?.port || configFile.localRuntimeConfig?.port || 3000,
   };
 

--- a/src/operon-runtime/config.ts
+++ b/src/operon-runtime/config.ts
@@ -28,7 +28,7 @@ export interface ConfigFile {
   telemetry?: TelemetryConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   application: any;
-  localRuntimeConfig?: OperonRuntimeConfig;
+  runtimeConfig?: OperonRuntimeConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dbClientMetadata?: any;
 }
@@ -120,10 +120,10 @@ export function parseConfigFile(cliOptions?: OperonCLIStartOptions): [OperonConf
   /*************************************/
   /* Build final runtime Configuration */
   /*************************************/
-  const localRuntimeConfig: OperonRuntimeConfig = {
-    entrypoint: cliOptions?.entrypoint || configFile.localRuntimeConfig?.entrypoint,
-    port: cliOptions?.port || configFile.localRuntimeConfig?.port || 3000,
+  const runtimeConfig: OperonRuntimeConfig = {
+    entrypoint: cliOptions?.entrypoint || configFile.runtimeConfig?.entrypoint,
+    port: cliOptions?.port || configFile.runtimeConfig?.port || 3000,
   };
 
-  return [operonConfig, localRuntimeConfig];
+  return [operonConfig, runtimeConfig];
 }

--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -19,6 +19,7 @@ describe("operon-config", () => {
         user_database: 'some DB'
       localRuntimeConfig:
         port: 1234
+        entrypoint: fake-entrypoint
       application:
         payments_url: 'http://somedomain.com/payment'
         foo: \${FOO}
@@ -64,6 +65,7 @@ describe("operon-config", () => {
     // local runtime config
     expect(runtimeConfig).toBeDefined();
     expect(runtimeConfig?.port).toBe(1234);
+    expect(runtimeConfig?.entrypoint).toBe("fake-entrypoint");
   });
 
   test("fails to read config file", () => {

--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -17,7 +17,7 @@ describe("operon-config", () => {
         password: \${PGPASSWORD}
         connectionTimeoutMillis: 3000
         user_database: 'some DB'
-      localRuntimeConfig:
+      runtimeConfig:
         port: 1234
         entrypoint: fake-entrypoint
       application:

--- a/tests/operon-runtime/runtime.test.ts
+++ b/tests/operon-runtime/runtime.test.ts
@@ -182,4 +182,3 @@ runtimeConfig:
   });
 });
 
-

--- a/tests/operon-runtime/runtime.test.ts
+++ b/tests/operon-runtime/runtime.test.ts
@@ -91,7 +91,7 @@ describe("runtime-entrypoint-tests", () => {
     await waitForMessageTest(command, "1234");
   });
 
-  test("runtime-hello using entrypoint localRuntimeConfig", async () => {
+  test("runtime-hello using entrypoint runtimeConfig", async () => {
     const mockOperonConfigYamlString = `
 database:
   hostname: 'localhost'
@@ -102,7 +102,7 @@ database:
   system_database: 'hello_systemdb'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
-localRuntimeConfig:
+runtimeConfig:
   entrypoint: dist/entrypoint.js
 `;
     const filePath = "operon-config.yaml";
@@ -163,7 +163,7 @@ database:
   system_database: 'hello_systemdb'
   connectionTimeoutMillis: 3000
   user_dbclient: 'knex'
-localRuntimeConfig:
+runtimeConfig:
   port: 6666
 `;
     const filePath = "operon-config.yaml";

--- a/tests/operon-runtime/runtime.test.ts
+++ b/tests/operon-runtime/runtime.test.ts
@@ -48,26 +48,85 @@ async function waitForMessageTest(command: ChildProcess, port: string) {
   }
 }
 
-describe("runtime-tests", () => {
+async function dropHelloSystemDB() {
+  const config = generateOperonTestConfig();
+  config.poolConfig.database = "hello";
+  await setupOperonTestDb(config);
+  const pgSystemClient = new Client({
+    user: config.poolConfig.user,
+    port: config.poolConfig.port,
+    host: config.poolConfig.host,
+    password: config.poolConfig.password,
+    database: "hello",
+  });
+  await pgSystemClient.connect();
+  await pgSystemClient.query(`DROP DATABASE IF EXISTS hello_systemdb;`);
+  await pgSystemClient.end();
+}
+
+function configureHelloExample() {
+  execSync("npm i");
+  execSync("npm run build");
+  execSync("npx knex migrate:up");
+}
+
+describe("runtime-entrypoint-tests", () => {
   beforeAll(async () => {
-    const config = generateOperonTestConfig();
-    config.poolConfig.database = "hello";
-    await setupOperonTestDb(config);
-    const pgSystemClient = new Client({
-      user: config.poolConfig.user,
-      port: config.poolConfig.port,
-      host: config.poolConfig.host,
-      password: config.poolConfig.password,
-      database: "hello",
-    });
-    await pgSystemClient.connect();
-    await pgSystemClient.query(`DROP DATABASE IF EXISTS hello_systemdb;`);
-    await pgSystemClient.end();
+    await dropHelloSystemDB();
 
     process.chdir("examples/hello");
-    execSync("npm i");
-    execSync("npm run build");
-    execSync("npx knex migrate:up");
+    execSync("mv src/operations.ts src/entrypoint.ts");
+    configureHelloExample();
+  });
+
+  afterAll(() => {
+    execSync("mv src/entrypoint.ts src/operations.ts");
+    process.chdir("../..");
+  });
+
+  test("runtime-hello using entrypoint CLI option", async () => {
+    const command = spawn("node_modules/@dbos-inc/operon/dist/src/operon-runtime/cli.js", ["start", "--port", "1234", "--entrypoint", "dist/entrypoint.js"], {
+      env: process.env,
+    });
+    await waitForMessageTest(command, "1234");
+  });
+
+  test("runtime-hello using entrypoint localRuntimeConfig", async () => {
+    const mockOperonConfigYamlString = `
+database:
+  hostname: 'localhost'
+  port: 5432
+  username: 'postgres'
+  password: \${PGPASSWORD}
+  user_database: 'hello'
+  system_database: 'hello_systemdb'
+  connectionTimeoutMillis: 3000
+  user_dbclient: 'knex'
+localRuntimeConfig:
+  entrypoint: dist/entrypoint.js
+`;
+    const filePath = "operon-config.yaml";
+    fs.copyFileSync(filePath, `${filePath}.bak`);
+    fs.writeFileSync(filePath, mockOperonConfigYamlString, "utf-8");
+
+    try {
+      const command = spawn("node_modules/@dbos-inc/operon/dist/src/operon-runtime/cli.js", ["start", "--port", "1234"], {
+        env: process.env,
+      });
+      await waitForMessageTest(command, "1234");
+    } finally {
+      fs.copyFileSync(`${filePath}.bak`, filePath);
+      fs.unlinkSync(`${filePath}.bak`);
+    }
+  });
+});
+
+describe("runtime-tests", () => {
+  beforeAll(async () => {
+    await dropHelloSystemDB();
+
+    process.chdir("examples/hello");
+    configureHelloExample();
   });
 
   afterAll(() => {
@@ -122,3 +181,5 @@ localRuntimeConfig:
     }
   });
 });
+
+


### PR DESCRIPTION
~still working on tests~

FYI, this PR has two somewhat unrelated changes:
* Update linter config to ignore `examples/` folder 
* rename `localRuntimeConfig` to `runtimeConfig`