### PR TITLE
make getConfig return a generic type

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -27,7 +27,7 @@ export interface OperonContext {
   readonly span: Span;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getConfig<T>(key: string, defaultValue?: T): T;
+  getConfig<T>(key: string, defaultValue?: T): T | undefined;
 }
 
 export class OperonContextImpl implements OperonContext {
@@ -52,13 +52,13 @@ export class OperonContextImpl implements OperonContext {
   /*** Application configuration ***/
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   applicationConfig?: any;
-  getConfig<T>(key: string, defaultValue?: T): T {
+  getConfig<T>(key: string, defaultValue?: T): T | undefined {
     // If there is no application config at all, or the key is missing, return the default value or undefined.
     if (!this.applicationConfig || !has(this.applicationConfig, key)) {
       if (defaultValue) {
         return defaultValue;
       }
-      return undefined as T;
+      return undefined;
     }
 
     // If the key is found and the default value is provided, check whether the value is of the same type.

--- a/src/context.ts
+++ b/src/context.ts
@@ -53,16 +53,8 @@ export class OperonContextImpl implements OperonContext {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   applicationConfig?: any;
   getConfig<T>(key: string, defaultValue?: T): T {
-    // If there is no application config at all, return the default value or undefined.
-    if (!this.applicationConfig) {
-      if (defaultValue) {
-        return defaultValue;
-      }
-      return undefined as T;
-    }
-
-    // If the key is not found in the application config, return the default value or undefined.
-    if (!has(this.applicationConfig, key)) {
+    // If there is no application config at all, or the key is missing, return the default value or undefined.
+    if (!this.applicationConfig || !has(this.applicationConfig, key)) {
       if (defaultValue) {
         return defaultValue;
       }

--- a/src/context.ts
+++ b/src/context.ts
@@ -26,8 +26,8 @@ export interface OperonContext {
   readonly logger: OperonLogger;
   readonly span: Span;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getConfig<T>(key: string, defaultValue?: T): T | undefined;
+  getConfig<T>(key: string): T | undefined;
+  getConfig<T>(key: string, defaultValue: T): T;
 }
 
 export class OperonContextImpl implements OperonContext {
@@ -52,6 +52,8 @@ export class OperonContextImpl implements OperonContext {
   /*** Application configuration ***/
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   applicationConfig?: any;
+  getConfig<T>(key: string): T | undefined;
+  getConfig<T>(key: string, defaultValue: T): T;
   getConfig<T>(key: string, defaultValue?: T): T | undefined {
     // If there is no application config at all, or the key is missing, return the default value or undefined.
     if (!this.applicationConfig || !has(this.applicationConfig, key)) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -26,7 +26,7 @@ export interface OperonContext {
   readonly span: Span;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getConfig(key: string): any;
+  getConfig<T>(key: string): T;
 }
 
 export class OperonContextImpl implements OperonContext {

--- a/src/error.ts
+++ b/src/error.ts
@@ -146,3 +146,11 @@ export class OperonUndefinedDecoratorInputError extends OperonError {
     super(`${decoratorName} received undefined input. Possible circular dependency?`, UndefinedDecoratorInputError);
   }
 }
+
+const ConfigKeyTypeError = 14;
+export class OperonConfigKeyTypeError extends OperonError {
+  constructor(configKey: string, expectedType: string, actualType: string) {
+    super(`${configKey} should be of type ${expectedType}, but got ${actualType}`, ConfigKeyTypeError);
+  }
+}
+

--- a/src/operon-runtime/config.ts
+++ b/src/operon-runtime/config.ts
@@ -121,7 +121,7 @@ export function parseConfigFile(cliOptions?: OperonCLIStartOptions): [OperonConf
   /* Build final runtime Configuration */
   /*************************************/
   const runtimeConfig: OperonRuntimeConfig = {
-    entrypoint: cliOptions?.entrypoint || configFile.runtimeConfig?.entrypoint,
+    entrypoint: cliOptions?.entrypoint || configFile.runtimeConfig?.entrypoint || "dist/operations.js",
     port: cliOptions?.port || configFile.runtimeConfig?.port || 3000,
   };
 

--- a/src/operon-runtime/runtime.ts
+++ b/src/operon-runtime/runtime.ts
@@ -12,7 +12,7 @@ interface ModuleExports {
 }
 
 export interface OperonRuntimeConfig {
-  entrypoint?: string;
+  entrypoint: string;
   port: number;
 }
 
@@ -50,7 +50,7 @@ export class OperonRuntime {
    * Load an application's Operon functions, assumed to be in src/operations.ts (which is compiled to dist/operations.js).
    */
   private loadFunctions(): Promise<ModuleExports> | null {
-    const entrypoint = this.runtimeConfig.entrypoint ?? "dist/operations.js";
+    const entrypoint = this.runtimeConfig.entrypoint;
     const operations = path.isAbsolute(entrypoint) ? entrypoint : path.join(process.cwd(), entrypoint);
     if (fs.existsSync(operations)) {
       /* eslint-disable-next-line @typescript-eslint/no-var-requires */

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -54,7 +54,7 @@ export interface OperonTestingRuntime {
 
   getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
-  getConfig<T>(key: string, defaultValue?: T): T; // Get application configuration.
+  getConfig<T>(key: string, defaultValue?: T): T | undefined; // Get application configuration.
 
   // User database operations.
   queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]>; // Execute a raw SQL query on the user database.
@@ -102,12 +102,12 @@ export class OperonTestingRuntimeImpl implements OperonTestingRuntime {
   /**
    * Get Application Configuration.
   */
-  getConfig<T>(key: string, defaultValue?: T): T {
+  getConfig<T>(key: string, defaultValue?: T): T | undefined {
     if (!this.#applicationConfig || !has(this.#applicationConfig, key)) {
       if (defaultValue) {
         return defaultValue;
       }
-      return undefined as T;
+      return undefined;
     }
 
     // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -103,6 +103,8 @@ export class OperonTestingRuntimeImpl implements OperonTestingRuntime {
   /**
    * Get Application Configuration.
   */
+  getConfig<T>(key: string): T | undefined;
+  getConfig<T>(key: string, defaultValue: T): T;
   getConfig<T>(key: string, defaultValue?: T): T | undefined {
     if (!this.#applicationConfig || !has(this.#applicationConfig, key)) {
       if (defaultValue) {

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -52,9 +52,9 @@ export interface OperonTestingRuntime {
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
 
-  getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>; 
+  getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
-  getConfig(key: string): any; // Get application configuration.
+  getConfig<T>(key: string): T; // Get application configuration.
 
   // User database operations.
   queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]>; // Execute a raw SQL query on the user database.

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -54,7 +54,8 @@ export interface OperonTestingRuntime {
 
   getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
-  getConfig<T>(key: string, defaultValue?: T): T | undefined; // Get application configuration.
+  getConfig<T>(key: string): T | undefined; // Get application configuration.
+  getConfig<T>(key: string, defaultValue: T): T;
 
   // User database operations.
   queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]>; // Execute a raw SQL query on the user database.

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -54,7 +54,7 @@ export interface OperonTestingRuntime {
 
   getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
 
-  getConfig<T>(key: string): T; // Get application configuration.
+  getConfig<T>(key: string, defaultValue?: T): T; // Get application configuration.
 
   // User database operations.
   queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]>; // Execute a raw SQL query on the user database.

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -3,7 +3,7 @@ import { IncomingMessage } from "http";
 import { OperonCommunicator } from "../communicator";
 import { HTTPRequest, OperonContextImpl } from "../context";
 import { getRegisteredOperations } from "../decorators";
-import { OperonError } from "../error";
+import { OperonConfigKeyTypeError, OperonError } from "../error";
 import { InvokeFuncs } from "../httpServer/handler";
 import { OperonHttpServer } from "../httpServer/server";
 import { Operon, OperonConfig } from "../operon";
@@ -102,14 +102,20 @@ export class OperonTestingRuntimeImpl implements OperonTestingRuntime {
   /**
    * Get Application Configuration.
   */
-  getConfig(key: string): any {
-    if (!this.#applicationConfig) {
-      return undefined;
+  getConfig<T>(key: string, defaultValue?: T): T {
+    if (!this.#applicationConfig || !has(this.#applicationConfig, key)) {
+      if (defaultValue) {
+        return defaultValue;
+      }
+      return undefined as T;
     }
-    if (!has(this.#applicationConfig, key)) {
-      return undefined;
+
+    // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment
+    const value = get(this.#applicationConfig, key);
+    if (defaultValue && typeof value !== typeof defaultValue) {
+      throw new OperonConfigKeyTypeError(key, typeof defaultValue, typeof value);
     }
-    return get(this.#applicationConfig, key);
+    return value as T;
   }
 
   /**

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -17,7 +17,7 @@ class TestClass {
   }
   @OperonCommunicator()
   static async testCommunicator(commCtxt: CommunicatorContext) {
-    expect(commCtxt.getConfig("counter")).toBe(3);
+    expect(commCtxt.getConfig<number>("counter")).toBe(3);
     void commCtxt;
     await sleep(1);
     return TestClass.#counter++;
@@ -25,14 +25,14 @@ class TestClass {
 
   @OperonWorkflow()
   static async testCommWorkflow(workflowCtxt: WorkflowContext) {
-    expect(workflowCtxt.getConfig("counter")).toBe(3);
+    expect(workflowCtxt.getConfig<number>("counter")).toBe(3);
     const funcResult = await workflowCtxt.invoke(TestClass).testCommunicator();
     return funcResult ?? -1;
   }
 
   @OperonTransaction()
   static async testInsertTx(txnCtxt: TestTransactionContext, name: string) {
-    expect(txnCtxt.getConfig("counter")).toBe(3);
+    expect(txnCtxt.getConfig<number>("counter")).toBe(3);
     const { rows } = await txnCtxt.client.query<TestKvTable>(`INSERT INTO ${testTableName}(value) VALUES ($1) RETURNING id`, [name]);
     return Number(rows[0].id);
   }
@@ -51,7 +51,7 @@ class TestClass {
   @OperonWorkflow()
   static async testTxWorkflow(wfCtxt: WorkflowContext, name: string) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(wfCtxt.getConfig("counter")).toBe(3);
+    expect(wfCtxt.getConfig<number>("counter")).toBe(3);
     const funcResult: number = await wfCtxt.invoke(TestClass).testInsertTx(name);
     const checkResult: number = await wfCtxt.invoke(TestClass).testReadTx(funcResult);
     return checkResult;

--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -4,11 +4,12 @@ import * as utils from "../../src/utils";
 import { PoolConfig } from "pg";
 import { parseConfigFile } from "../../src/operon-runtime/config";
 import { OperonRuntimeConfig } from "../../src/operon-runtime/runtime";
-import { OperonInitializationError } from "../../src/error";
-import { OperonConfig } from "../../src/operon";
+import { OperonConfigKeyTypeError, OperonInitializationError } from "../../src/error";
+import { Operon, OperonConfig } from "../../src/operon";
+import { WorkflowContextImpl } from "../../src/workflow";
 
 describe("operon-config", () => {
-  const mockCLIOptions = {port: NaN, loglevel: "info"};
+  const mockCLIOptions = { port: NaN, loglevel: "info" };
   const mockOperonConfigYamlString = `
       database:
         hostname: 'some host'
@@ -36,59 +37,99 @@ describe("operon-config", () => {
     jest.restoreAllMocks();
   });
 
-  test("Config is valid and is parsed as expected", () => {
-    jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
-    jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+  describe("Configuration parsing", () => {
+    test("Config is valid and is parsed as expected", () => {
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
 
-    const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
 
-    // Test pool config options
-    const poolConfig: PoolConfig = operonConfig.poolConfig;
-    expect(poolConfig.host).toBe("some host");
-    expect(poolConfig.port).toBe(1234);
-    expect(poolConfig.user).toBe("some user");
-    expect(poolConfig.password).toBe(process.env.PGPASSWORD);
-    expect(poolConfig.connectionTimeoutMillis).toBe(3000);
-    expect(poolConfig.database).toBe("some DB");
+      // Test pool config options
+      const poolConfig: PoolConfig = operonConfig.poolConfig;
+      expect(poolConfig.host).toBe("some host");
+      expect(poolConfig.port).toBe(1234);
+      expect(poolConfig.user).toBe("some user");
+      expect(poolConfig.password).toBe(process.env.PGPASSWORD);
+      expect(poolConfig.connectionTimeoutMillis).toBe(3000);
+      expect(poolConfig.database).toBe("some DB");
 
-    // Application config
-    const applicationConfig: any = operonConfig.application;
-    expect(applicationConfig.payments_url).toBe("http://somedomain.com/payment");
-    expect(applicationConfig.foo).toBe("foo");
-    expect(applicationConfig.bar).toBe("bar");
-    expect(applicationConfig.nested.baz).toBe("baz");
-    expect(applicationConfig.nested.a).toBeInstanceOf(Array);
-    expect(applicationConfig.nested.a).toHaveLength(3);
-    expect(applicationConfig.nested.a[2].b.c).toBe("c");
+      // Application config
+      const applicationConfig: any = operonConfig.application;
+      expect(applicationConfig.payments_url).toBe("http://somedomain.com/payment");
+      expect(applicationConfig.foo).toBe(process.env.FOO);
+      expect(applicationConfig.bar).toBe(process.env.BAR);
+      expect(applicationConfig.nested.baz).toBe(process.env.BAZ);
+      expect(applicationConfig.nested.a).toBeInstanceOf(Array);
+      expect(applicationConfig.nested.a).toHaveLength(3);
+      expect(applicationConfig.nested.a[2].b.c).toBe(process.env.C);
 
-    // local runtime config
-    expect(runtimeConfig).toBeDefined();
-    expect(runtimeConfig?.port).toBe(1234);
-  });
-
-  test("fails to read config file", () => {
-    jest.spyOn(utils, "readFileSync").mockImplementation(() => {
-      throw new OperonInitializationError("some error");
+      // local runtime config
+      expect(runtimeConfig).toBeDefined();
+      expect(runtimeConfig?.port).toBe(1234);
     });
-    expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
+
+    test("fails to read config file", () => {
+      jest.spyOn(utils, "readFileSync").mockImplementation(() => {
+        throw new OperonInitializationError("some error");
+      });
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
+    });
+
+    test("config file is empty", () => {
+      const mockConfigFile = "";
+      jest.spyOn(utils, "readFileSync").mockReturnValue(JSON.stringify(mockConfigFile));
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
+    });
+
+    test("config file is missing database config", () => {
+      const mockConfigFile = { someOtherConfig: "some other config" };
+      jest.spyOn(utils, "readFileSync").mockReturnValue(JSON.stringify(mockConfigFile));
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
+    });
+
+    test("config file is missing database password", () => {
+      const dbPassword = process.env.PGPASSWORD;
+      delete process.env.PGPASSWORD;
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
+      process.env.PGPASSWORD = dbPassword;
+    });
   });
 
-  test("config file is empty", () => {
-    const mockConfigFile = "";
-    jest.spyOn(utils, "readFileSync").mockReturnValue(JSON.stringify(mockConfigFile));
-    expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
-  });
+  describe("context getConfig()", () => {
+    beforeEach(() => {
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
+      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+    });
 
-  test("config file is missing database config", () => {
-    const mockConfigFile = { someOtherConfig: "some other config" };
-    jest.spyOn(utils, "readFileSync").mockReturnValue(JSON.stringify(mockConfigFile));
-    expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
-  });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
-  test("config file is missing database password", () => {
-    delete process.env.PGPASSWORD;
-    jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
-    jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
-    expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
+    test("getConfig returns the expected values", async () => {
+      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const operon = new Operon(operonConfig);
+      const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");
+      // Config key exists
+      expect(ctx.getConfig<string>("payments_url")).toBe("http://somedomain.com/payment");
+      // Config key does not exist, no default value
+      expect(ctx.getConfig<string>("no_key")).toBeUndefined();
+      // Config key does not exist, default value
+      expect(ctx.getConfig<string>("no_key", "default")).toBe("default");
+      // We didn't init, so do some manual cleanup only
+      clearInterval(operon.flushBufferID);
+      await operon.telemetryCollector.destroy();
+    });
+
+    test("getConfig throws when it finds a value of different type than the default", async () => {
+      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const operon = new Operon(operonConfig);
+      const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");
+      expect(() => ctx.getConfig<number>("payments_url", 1234)).toThrow(OperonConfigKeyTypeError);
+      // We didn't init, so do some manual cleanup only
+      clearInterval(operon.flushBufferID);
+      await operon.telemetryCollector.destroy();
+    });
   });
 });

--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -40,8 +40,7 @@ describe("operon-config", () => {
 
   describe("Configuration parsing", () => {
     test("Config is valid and is parsed as expected", () => {
-      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
-      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+      jest.spyOn(utils, "readFileSync").mockReturnValue(mockOperonConfigYamlString);
 
       const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
 
@@ -101,8 +100,7 @@ describe("operon-config", () => {
 
   describe("context getConfig()", () => {
     beforeEach(() => {
-      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
-      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+      jest.spyOn(utils, "readFileSync").mockReturnValue(mockOperonConfigYamlString);
     });
 
     afterEach(() => {
@@ -135,8 +133,7 @@ describe("operon-config", () => {
           user_database: 'some DB'
       `;
       jest.restoreAllMocks();
-      jest.spyOn(utils, "readFileSync").mockReturnValueOnce(localMockOperonConfigYamlString);
-      jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
+      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockOperonConfigYamlString);
       const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const operon = new Operon(operonConfig);
       const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");

--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -112,11 +112,11 @@ describe("operon-config", () => {
       const operon = new Operon(operonConfig);
       const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");
       // Config key exists
-      expect(ctx.getConfig<string>("payments_url")).toBe("http://somedomain.com/payment");
+      expect(ctx.getConfig("payments_url")).toBe("http://somedomain.com/payment");
       // Config key does not exist, no default value
-      expect(ctx.getConfig<string>("no_key")).toBeUndefined();
+      expect(ctx.getConfig("no_key")).toBeUndefined();
       // Config key does not exist, default value
-      expect(ctx.getConfig<string>("no_key", "default")).toBe("default");
+      expect(ctx.getConfig("no_key", "default")).toBe("default");
       // We didn't init, so do some manual cleanup only
       clearInterval(operon.flushBufferID);
       await operon.telemetryCollector.destroy();

--- a/tests/testing/testing_runtime.test.ts
+++ b/tests/testing/testing_runtime.test.ts
@@ -19,7 +19,7 @@ describe("testruntime-test", () => {
 
   test("simple-workflow", async () => {
     const res = await testRuntime.invoke(TestClass).testWorkflow(username).then(x => x.getResult());
-    const expectName = testRuntime.getConfig("testvalue") as string; // Read application config.
+    const expectName = testRuntime.getConfig<string>("testvalue"); // Read application config.
     expect(JSON.parse(res)).toEqual({ current_user: expectName });
   });
 


### PR DESCRIPTION
Now we can use `getConfig` as follows:

Configuration file:
```yaml
database:
   ...
application:
  foo:
    - bar
    - baz
```

User code:

```typescript
interface myProperties {
    list: string[];
}

...

@GetApi("/greeting/:name")
static async helloHandler(ctx: HandlerContext, name: string) {
  const fooProperty = ctx.getConfig<myProperties>("foo");
}
```
