### PR TITLE
Add authenticatedRoles and assumedRole to OperonContext

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -22,6 +22,8 @@ export interface OperonContext {
   readonly request: HTTPRequest;
   readonly workflowUUID: string;
   readonly authenticatedUser: string;
+  readonly authenticatedRoles: string[];
+  readonly assumedRole: string;
 
   readonly logger: OperonLogger;
   readonly span: Span;

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -283,7 +283,16 @@ describe("httpserver-tests", () => {
     // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/requireduser")
     @RequiredRole(["user"])
-    static async testAuth(_ctxt: HandlerContext, name: string) {
+    static async testAuth(ctxt: HandlerContext, name: string) {
+      if (ctxt.authenticatedUser !== "a_real_user") {
+        throw new OperonResponseError("uid not a real user!", 400);
+      }
+      if (!ctxt.authenticatedRoles.includes("user")) {
+        throw new OperonResponseError("roles don't include user!", 400);
+      }
+      if (ctxt.assumedRole !== "user") {
+        throw new OperonResponseError("Should never happen! Not assumed to be user", 400);
+      }
       return `Please say hello to ${name}`;
     }
   }


### PR DESCRIPTION
Now all contexts should be able to access `authenticatedRoles` and `assumedRole`.
Will update Operon-docs accordingly.