### PR TITLE
Update Deploy

### DIFF
--- a/examples/hello/knexfile.ts
+++ b/examples/hello/knexfile.ts
@@ -13,6 +13,7 @@ const config: Knex.Config = {
     user: operonConfig.poolConfig.user,
     password: operonConfig.poolConfig.password,
     database: operonConfig.poolConfig.database,
+    ssl: operonConfig.config.poolConfig.ssl,
   },
   migrations: {
     directory: './migrations'

--- a/examples/hello/knexfile.ts
+++ b/examples/hello/knexfile.ts
@@ -13,7 +13,7 @@ const config: Knex.Config = {
     user: operonConfig.poolConfig.user,
     password: operonConfig.poolConfig.password,
     database: operonConfig.poolConfig.database,
-    ssl: operonConfig.config.poolConfig.ssl,
+    ssl: operonConfig.poolConfig.ssl,
   },
   migrations: {
     directory: './migrations'

--- a/src/operon-runtime/deploy.ts
+++ b/src/operon-runtime/deploy.ts
@@ -5,6 +5,7 @@ import FormData from 'form-data';
 
 export async function deploy(appName: string, host: string) {
 
+    const tempHardcodedToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.p5Csu2THYW5zJys2CWdbGM8GaWjpY6lOQpdLoP4D7V4";
     try {
         const register = await axios.post(
             `http://${host}:8080/application/register`,
@@ -14,6 +15,7 @@ export async function deploy(appName: string, host: string) {
             {
                 headers: {
                     'Content-Type': 'application/json',
+                    'Authorization': tempHardcodedToken,
                 },
             },
         );
@@ -27,6 +29,7 @@ export async function deploy(appName: string, host: string) {
         await axios.post(`http://${host}:8080/application/${uuid}`, formData, {
             headers: {
                 ...formData.getHeaders(),
+                'Authorization': tempHardcodedToken,
             },
         });
         console.log(`Successfully deployed: ${appName}`);

--- a/src/operon-runtime/deploy.ts
+++ b/src/operon-runtime/deploy.ts
@@ -21,7 +21,9 @@ export async function deploy(appName: string, host: string) {
         );
         const uuid = register.data as string;
         execSync(`mkdir -p operon_deploy`);
-        execSync(`zip -ry operon_deploy/${uuid}.zip ./* -x "operon_deploy/*"`)
+        execSync(`envsubst < operon-config.yaml > operon_deploy/operon-config.yaml`);
+        execSync(`zip -ry operon_deploy/${uuid}.zip ./* -x operon_deploy/* operon-config.yaml`);
+        execSync(`zip -j operon_deploy/${uuid}.zip operon_deploy/operon-config.yaml`);
 
         const formData = new FormData();
         formData.append('app_archive', fs.createReadStream(`operon_deploy/${uuid}.zip`));

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -163,6 +163,7 @@ export class Operon {
           user: this.config.poolConfig.user,
           password: this.config.poolConfig.password,
           database: this.config.poolConfig.database,
+          ssl: this.config.poolConfig.ssl,
         }
       }
       this.userDatabase = new KnexUserDatabase(knex(knexConfig));


### PR DESCRIPTION
This PR updates `npx operon deploy` so it's fully compatible with the latest versions of Operon and the cloud prototype.

In the near future, may move the cloud commands into a separate package, or even a separate repository.