### PR TITLE
OAOO for getEvent and getWorkflowStatus within a workflow

### DIFF
--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -199,7 +199,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     });
   }
 
-  async getWorkflowStatus(workflowUUID: string, functionID?: number): Promise<WorkflowStatus | null> {
+  async getWorkflowStatus(workflowUUID: string, callerUUID?: string, functionID?: number): Promise<WorkflowStatus | null> {
     const output = (await this.workflowStatusDB.get(workflowUUID)) as WorkflowOutput<unknown> | undefined;
     if (output === undefined) {
       return null;
@@ -313,7 +313,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     });
   }
 
-  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number, functionID?: number): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number, callerUUID?: string, functionID?: number): Promise<T | null> {
     // Check if the value is present, otherwise wait for it to arrive.
     const watch = await this.workflowEventsDB.getAndWatch([workflowUUID, key]);
     if (watch.value === undefined) {

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -159,7 +159,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     return await this.workflowInputsDB.get(workflowUUID) as T ?? null;
   }
 
-  async checkCommunicatorOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R> {
+  async checkOperationOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R> {
     const output = (await this.operationOutputsDB.get([workflowUUID, functionID])) as OperationOutput<R> | undefined;
     if (output === undefined) {
       return operonNull;
@@ -170,7 +170,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     }
   }
 
-  async recordCommunicatorOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void> {
+  async recordOperationOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void> {
     await this.operationOutputsDB.doTransaction(async (txn) => {
       // Check if the key exists.
       const keyOutput = await txn.get([workflowUUID, functionID]);
@@ -184,7 +184,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     });
   }
 
-  async recordCommunicatorError(workflowUUID: string, functionID: number, error: Error): Promise<void> {
+  async recordOperationError(workflowUUID: string, functionID: number, error: Error): Promise<void> {
     const serialErr = JSON.stringify(serializeError(error));
     await this.operationOutputsDB.doTransaction(async (txn) => {
       // Check if the key exists.
@@ -199,7 +199,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     });
   }
 
-  async getWorkflowStatus(workflowUUID: string): Promise<WorkflowStatus | null> {
+  async getWorkflowStatus(workflowUUID: string, functionID?: number): Promise<WorkflowStatus | null> {
     const output = (await this.workflowStatusDB.get(workflowUUID)) as WorkflowOutput<unknown> | undefined;
     if (output === undefined) {
       return null;

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -200,11 +200,32 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   }
 
   async getWorkflowStatus(workflowUUID: string, callerUUID?: string, functionID?: number): Promise<WorkflowStatus | null> {
-    const output = (await this.workflowStatusDB.get(workflowUUID)) as WorkflowOutput<unknown> | undefined;
-    if (output === undefined) {
-      return null;
+    // Check if the operation has been done before for OAOO (only do this inside a workflow).
+    if (callerUUID !== undefined && functionID !== undefined) {
+      const prev = (await this.operationOutputsDB.get([callerUUID, functionID])) as OperationOutput<WorkflowStatus | null> | undefined;
+      if (prev !== undefined) {
+        return prev.output;
+      }
     }
-    return { status: output.status, workflowName: output.name, authenticatedUser: output.authenticatedUser, authenticatedRoles: output.authenticatedRoles, assumedRole: output.assumedRole, request: output.request };
+
+    const output = (await this.workflowStatusDB.get(workflowUUID)) as WorkflowOutput<unknown> | undefined;
+    let value = null;
+    if (output !== undefined) {
+      value = {
+        status: output.status,
+        workflowName: output.name,
+        authenticatedUser: output.authenticatedUser,
+        authenticatedRoles: output.authenticatedRoles,
+        assumedRole: output.assumedRole,
+        request: output.request,
+      };
+    }
+
+    // Record the output if it is inside a workflow.
+    if (callerUUID !== undefined && functionID !== undefined) {
+      await this.recordOperationOutput(callerUUID, functionID, value);
+    }
+    return value;
   }
 
   async getWorkflowResult<R>(workflowUUID: string): Promise<R> {
@@ -314,6 +335,14 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   }
 
   async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number, callerUUID?: string, functionID?: number): Promise<T | null> {
+    // Check if the operation has been done before for OAOO (only do this inside a workflow).
+    if (callerUUID !== undefined && functionID !== undefined) {
+      const output = (await this.operationOutputsDB.get([callerUUID, functionID])) as OperationOutput<T | null> | undefined;
+      if (output !== undefined) {
+        return output.output;
+      }
+    }
+
     // Check if the value is present, otherwise wait for it to arrive.
     const watch = await this.workflowEventsDB.getAndWatch([workflowUUID, key]);
     if (watch.value === undefined) {
@@ -326,6 +355,17 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
       watch.cancel();
     }
     // Return the value, or null if none exists.
-    return (await this.workflowEventsDB.get([workflowUUID, key])) as T ?? null;
+    let value: T | null = null;
+    if (watch.value !== undefined) {
+      value = watch.value as T;
+    } else {
+      value = ((await this.workflowEventsDB.get([workflowUUID, key])) as T) ?? null;
+    }
+
+    // Record the output if it is inside a workflow.
+    if (callerUUID !== undefined && functionID !== undefined) {
+      await this.recordOperationOutput(callerUUID, functionID, value);
+    }
+    return value;
   }
 }

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -313,7 +313,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     });
   }
 
-  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number, functionID?: number): Promise<T | null> {
     // Check if the value is present, otherwise wait for it to arrive.
     const watch = await this.workflowEventsDB.getAndWatch([workflowUUID, key]);
     if (watch.value === undefined) {

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -354,9 +354,10 @@ export class Operon {
 
   /**
    * Wait for a workflow to emit an event, then return its value.
+   * If functionID is set, the getEvent is called from within a workflow.
    */
-  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = Operon.defaultNotificationTimeoutSec): Promise<T | null> {
-    return this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds);
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = Operon.defaultNotificationTimeoutSec, functionID?: number): Promise<T | null> {
+    return this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds, functionID);
   }
 
   /**

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -270,6 +270,11 @@ export class Operon {
   }
 
   async workflow<T extends any[], R>(wf: OperonWorkflow<T, R>, params: WorkflowParams, ...args: T): Promise<WorkflowHandle<R>> {
+    return this.internalWorkflow(wf, params, undefined, undefined, ...args);
+  }
+
+  // If callerUUID and functionID are set, it means the workflow is invoked from within a workflow.
+  async internalWorkflow<T extends any[], R>(wf: OperonWorkflow<T, R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
     const workflowUUID: string = params.workflowUUID ? params.workflowUUID : this.#generateUUID();
 
     const wInfo = this.workflowInfoMap.get(wf.name);
@@ -322,7 +327,7 @@ export class Operon {
       return result!;
     };
     const workflowPromise: Promise<R> = runWorkflow();
-    return new InvokedHandle(this.systemDatabase, workflowPromise, workflowUUID, wf.name);
+    return new InvokedHandle(this.systemDatabase, workflowPromise, workflowUUID, wf.name, callerUUID, callerFunctionID);
   }
 
   async transaction<T extends any[], R>(txn: OperonTransaction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -354,10 +354,9 @@ export class Operon {
 
   /**
    * Wait for a workflow to emit an event, then return its value.
-   * If functionID is set, the getEvent is called from within a workflow.
    */
-  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = Operon.defaultNotificationTimeoutSec, functionID?: number): Promise<T | null> {
-    return this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds, functionID);
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = Operon.defaultNotificationTimeoutSec): Promise<T | null> {
+    return this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds);
   }
 
   /**

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -22,11 +22,11 @@ export interface SystemDatabase {
   getPendingWorkflows(): Promise<Array<string>>;
   getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null>;
 
-  checkCommunicatorOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R>;
-  recordCommunicatorOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void>;
-  recordCommunicatorError(workflowUUID: string, functionID: number, error: Error): Promise<void>;
+  checkOperationOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R>;
+  recordOperationOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void>;
+  recordOperationError(workflowUUID: string, functionID: number, error: Error): Promise<void>;
 
-  getWorkflowStatus(workflowUUID: string): Promise<WorkflowStatus | null>;
+  getWorkflowStatus(workflowUUID: string, functionID?: number): Promise<WorkflowStatus | null>;
   getWorkflowResult<R>(workflowUUID: string): Promise<R>;
 
   send<T extends NonNullable<any>>(workflowUUID: string, functionID: number, destinationUUID: string, message: T, topic?: string): Promise<void>;
@@ -149,7 +149,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     return JSON.parse(rows[0].inputs) as T;
   }
 
-  async checkCommunicatorOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R> {
+  async checkOperationOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R> {
     const { rows } = await this.pool.query<operation_outputs>("SELECT output, error FROM operation_outputs WHERE workflow_uuid=$1 AND function_id=$2", [workflowUUID, functionID]);
     if (rows.length === 0) {
       return operonNull;
@@ -160,7 +160,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  async recordCommunicatorOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void> {
+  async recordOperationOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void> {
     const serialOutput = JSON.stringify(output);
     try {
       await this.pool.query("INSERT INTO operation_outputs (workflow_uuid, function_id, output) VALUES ($1, $2, $3);", [workflowUUID, functionID, serialOutput]);
@@ -175,7 +175,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  async recordCommunicatorError(workflowUUID: string, functionID: number, error: Error): Promise<void> {
+  async recordOperationError(workflowUUID: string, functionID: number, error: Error): Promise<void> {
     const serialErr = JSON.stringify(serializeError(error));
     try {
       await this.pool.query("INSERT INTO operation_outputs (workflow_uuid, function_id, error) VALUES ($1, $2, $3);", [workflowUUID, functionID, serialErr]);
@@ -359,19 +359,38 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
     // Record the output if it is inside a workflow.
     if (functionID !== undefined) {
-      const client: PoolClient = await this.pool.connect();
-      await this.recordNotificationOutput(client, workflowUUID, functionID, value);
+      await this.recordOperationOutput(workflowUUID, functionID, value);
     }
     return value;
   }
 
-  async getWorkflowStatus(workflowUUID: string): Promise<WorkflowStatus | null> {
-    const { rows } = await this.pool.query<workflow_status>("SELECT status, name, authenticated_user, assumed_role, authenticated_roles, request FROM workflow_status WHERE workflow_uuid=$1", [workflowUUID]);
-    if (rows.length === 0) {
-      return null;
+  async getWorkflowStatus(workflowUUID: string, functionID?: number): Promise<WorkflowStatus | null> {
+    // Check if the operation has been done before for OAOO (only do this inside a workflow).
+    if (functionID !== undefined) {
+      const { rows } = await this.pool.query<operation_outputs>("SELECT output FROM operation_outputs WHERE workflow_uuid=$1 AND function_id=$2", [workflowUUID, functionID]);
+      if (rows.length > 0) {
+        return JSON.parse(rows[0].output) as WorkflowStatus;
+      }
     }
-    return { status: rows[0].status, workflowName: rows[0].name, authenticatedUser: rows[0].authenticated_user, assumedRole: rows[0].assumed_role, authenticatedRoles: JSON.parse(rows[0].authenticated_roles) as string[],
-    request: JSON.parse(rows[0].request) as HTTPRequest };
+
+    const { rows } = await this.pool.query<workflow_status>("SELECT status, name, authenticated_user, assumed_role, authenticated_roles, request FROM workflow_status WHERE workflow_uuid=$1", [workflowUUID]);
+    let value = null;
+    if (rows.length > 0) {
+      value = {
+        status: rows[0].status,
+        workflowName: rows[0].name,
+        authenticatedUser: rows[0].authenticated_user,
+        assumedRole: rows[0].assumed_role,
+        authenticatedRoles: JSON.parse(rows[0].authenticated_roles) as string[],
+        request: JSON.parse(rows[0].request) as HTTPRequest,
+      };
+    }
+
+    // Record the output if it is inside a workflow.
+    if (functionID !== undefined) {
+      await this.recordOperationOutput(workflowUUID, functionID, value);
+    }
+    return value;
   }
 
   async getWorkflowResult<R>(workflowUUID: string): Promise<R> {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -485,14 +485,15 @@ export interface WorkflowHandle<R> {
  * The handle returned when invoking a workflow with Operon.workflow
  */
 export class InvokedHandle<R> implements WorkflowHandle<R> {
-  constructor(readonly systemDatabase: SystemDatabase, readonly workflowPromise: Promise<R>, readonly workflowUUID: string, readonly workflowName: string) {}
+  constructor(readonly systemDatabase: SystemDatabase, readonly workflowPromise: Promise<R>, readonly workflowUUID: string, readonly workflowName: string,
+    readonly callerUUID?: string, readonly callerFunctionID?: number) {}
 
   getWorkflowUUID(): string {
     return this.workflowUUID;
   }
 
   async getStatus(): Promise<WorkflowStatus | null> {
-    return this.systemDatabase.getWorkflowStatus(this.workflowUUID);
+    return this.systemDatabase.getWorkflowStatus(this.workflowUUID, this.callerUUID, this.callerFunctionID);
   }
 
   async getResult(): Promise<R> {
@@ -504,14 +505,14 @@ export class InvokedHandle<R> implements WorkflowHandle<R> {
  * The handle returned when retrieving a workflow with Operon.retrieve
  */
 export class RetrievedHandle<R> implements WorkflowHandle<R> {
-  constructor(readonly systemDatabase: SystemDatabase, readonly workflowUUID: string, readonly callerUUID?: string, readonly functionID?: number) {}
+  constructor(readonly systemDatabase: SystemDatabase, readonly workflowUUID: string, readonly callerUUID?: string, readonly callerFunctionID?: number) {}
 
   getWorkflowUUID(): string {
     return this.workflowUUID;
   }
 
   async getStatus(): Promise<WorkflowStatus | null> {
-    return await this.systemDatabase.getWorkflowStatus(this.workflowUUID, this.callerUUID, this.functionID);
+    return await this.systemDatabase.getWorkflowStatus(this.workflowUUID, this.callerUUID, this.callerFunctionID);
   }
 
   async getResult(): Promise<R> {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -321,7 +321,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
     this.resultBuffer.clear();
 
     // Check if this execution previously happened, returning its original result if it did.
-    const check: R | OperonNull = await this.#operon.systemDatabase.checkCommunicatorOutput<R>(this.workflowUUID, ctxt.functionID);
+    const check: R | OperonNull = await this.#operon.systemDatabase.checkOperationOutput<R>(this.workflowUUID, ctxt.functionID);
     if (check !== operonNull) {
       ctxt.span.setAttribute("cached", true);
       ctxt.span.setStatus({ code: SpanStatusCode.OK });
@@ -363,13 +363,13 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
     if (result === operonNull) {
       // Record the error, then throw it.
       err = err === operonNull ? new OperonError("Communicator reached maximum retries.", 1) : err;
-      await this.#operon.systemDatabase.recordCommunicatorError(this.workflowUUID, ctxt.functionID, err as Error);
+      await this.#operon.systemDatabase.recordOperationError(this.workflowUUID, ctxt.functionID, err as Error);
       ctxt.span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
       this.#operon.tracer.endSpan(ctxt.span);
       throw err;
     } else {
       // Record the execution and return.
-      await this.#operon.systemDatabase.recordCommunicatorOutput<R>(this.workflowUUID, ctxt.functionID, result as R);
+      await this.#operon.systemDatabase.recordOperationOutput<R>(this.workflowUUID, ctxt.functionID, result as R);
       ctxt.span.setStatus({ code: SpanStatusCode.OK });
       this.#operon.tracer.endSpan(ctxt.span);
       return result as R;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -62,6 +62,9 @@ export interface WorkflowContext extends OperonContext {
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string): Promise<void>;
   recv<T extends NonNullable<any>>(topic?: string, timeoutSeconds?: number): Promise<T | null>;
   setEvent<T extends NonNullable<any>>(key: string, value: T): Promise<void>;
+
+  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
+  retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
 }
 
 export class WorkflowContextImpl extends OperonContextImpl implements WorkflowContext {
@@ -444,15 +447,15 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
    * Wait for a workflow to emit an event, then return its value.
    */
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = Operon.defaultNotificationTimeoutSec): Promise<T | null> {
-    // FIXME: make this deterministic and expose in the public interface.
-    return this.#operon.getEvent(workflowUUID, key, timeoutSeconds);
+    const functionID: number = this.functionIDGetIncrement();
+    return this.#operon.getEvent(workflowUUID, key, timeoutSeconds, functionID);
   }
 
   /**
    * Retrieve a handle for a workflow UUID.
    */
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R> {
-    // FIXME: make this deterministic and expose in the public interface.
+    // TODO: make workflow handle deterministic. E.g., getStatus is not deterministic.
     return this.#operon.retrieveWorkflow(workflowUUID);
   }
 

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -27,6 +27,7 @@ describe("foundationdb-operon", () => {
     await systemDB.operationOutputsDB.clearRangeStartsWith([]);
     await systemDB.notificationsDB.clearRangeStartsWith([]);
     FdbTestClass.cnt = 0;
+    FdbTestClass.wfCnt = 0;
   });
 
   afterEach(async () => {
@@ -152,10 +153,33 @@ describe("foundationdb-operon", () => {
     await expect(handle.getResult()).resolves.toBe(5);
     expect(FdbTestClass.cnt).toBe(10); // Should run twice.
   });
+
+  test("workflow-getevent-retrieve", async() => {
+    // Execute a workflow (w/ getUUID) to get an event and retrieve a workflow that doesn't exist, then invoke the setEvent workflow as a child workflow.
+    // If we execute the get workflow without UUID, both getEvent and retrieveWorkflow should return values.
+    // But if we run the get workflow again with getUUID, getEvent/retrieveWorkflow should still return null.
+    const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer.
+
+    const getUUID = uuidv1();
+    const setUUID = getUUID + "-2";
+
+    await expect(testRuntime.invoke(FdbTestClass, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-0");
+    expect(FdbTestClass.wfCnt).toBe(2);
+    await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
+
+    // Run without UUID, should get the new result.
+    await expect(testRuntime.invoke(FdbTestClass).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("value1-PENDING-0");
+
+    // Test OAOO for getEvent and getWorkflowStatus.
+    await expect(testRuntime.invoke(FdbTestClass, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-0");
+    expect(FdbTestClass.wfCnt).toBe(6);  // Should re-execute the workflow because we're not flushing the result buffer.
+  });
 });
 
 class FdbTestClass {
   static cnt = 0;
+  static wfCnt = 0;
 
   // eslint-disable-next-line @typescript-eslint/require-await
   @OperonTransaction()
@@ -239,6 +263,32 @@ class FdbTestClass {
     await ctxt.setEvent("key1", "value1");
     await ctxt.setEvent("key2", "value2");
     return 0;
+  }
+
+  @OperonWorkflow()
+  static async getEventRetrieveWorkflow(ctxt: WorkflowContext, targetUUID: string): Promise<string> {
+    let res = "";
+    const getValue = await ctxt.getEvent<string>(targetUUID, "key1", 0);
+    FdbTestClass.wfCnt++;
+    if (getValue === null) {
+      res = "valueNull";
+    } else {
+      res = getValue;
+    }
+
+    const handle = ctxt.retrieveWorkflow(targetUUID);
+    const status = await handle.getStatus();
+    FdbTestClass.wfCnt++;
+    if (status === null) {
+      res += "-statusNull";
+    } else {
+      res += "-" + status.status;
+    }
+
+    // Note: the targetUUID must match the child workflow UUID.
+    const value = await ctxt.childWorkflow(FdbTestClass.setEventWorkflow).then(x => x.getResult());
+    res += "-" + value;
+    return res;
   }
 
   @OperonWorkflow()


### PR DESCRIPTION
This PR adds `getEvent()` and `retrieveWorkflow()` methods to the `WorkflowContext` public interface, and guarantees `getEvent()` and `handle.getStatus()` to be executed exactly-once inside workflows.
Previously, these two operations may return different results if retried (e.g., due to timeouts or workflow status change), which may violate our OAOO guarantees.

Specifically, this PR:
- Updates `getEvent()` and `getWorkflowStatus()`in system databases (both PG and FDB) to check and record the output to guarantee OAOO (only if called within a workflow).
- Use `callerUUID` and `callerFunctionID` to differentiate function calls inside vs. outside of a workflow. We only guarantee OAOO when `getEvent()` or `getStatus()` are called within a workflow.
- Adds a test in both operon.test.ts and foundationdb.test.ts.