### PR TITLE
Operon CLI login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.operon/
 # Logs
 logs
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "commander": "^11.0.0",
         "fast-glob": "^3.3.1",
         "form-data": "^4.0.0",
+        "jwt-simple": "^0.5.6",
         "knex": "^2.5.1",
         "koa": "^2.14.2",
         "koa-logger": "^3.2.1",
@@ -5294,6 +5295,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-simple": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.6.tgz",
+      "integrity": "sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/keygrip": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "commander": "^11.0.0",
     "fast-glob": "^3.3.1",
     "form-data": "^4.0.0",
+    "jwt-simple": "^0.5.6",
     "knex": "^2.5.1",
     "koa": "^2.14.2",
     "koa-logger": "^3.2.1",

--- a/src/operon-runtime/cli.ts
+++ b/src/operon-runtime/cli.ts
@@ -56,8 +56,8 @@ program
   .command('login')
   .description('Log in Operon cloud')
   .requiredOption('-u, --userName <string>', 'User name for login', )
-  .action(async (options: { userName: string }) => {
-    await login(options.userName);
+  .action((options: { userName: string }) => {
+    login(options.userName);
   });
 
 program

--- a/src/operon-runtime/cli.ts
+++ b/src/operon-runtime/cli.ts
@@ -6,6 +6,7 @@ import { OperonRuntime, OperonRuntimeConfig } from "./runtime";
 import { Command } from 'commander';
 import { OperonConfig } from "../operon";
 import { init } from "./init";
+import { login } from "./login";
 
 const program = new Command();
 
@@ -50,6 +51,14 @@ program
 ///////////////////////
 /* CLOUD DEPLOYMENT  */
 ///////////////////////
+
+program
+  .command('login')
+  .description('Log in Operon cloud')
+  .requiredOption('-u, --userName <string>', 'User name for login', )
+  .action(async (options: { userName: string }) => {
+    await login(options.userName);
+  });
 
 program
   .command('deploy')

--- a/src/operon-runtime/deploy.ts
+++ b/src/operon-runtime/deploy.ts
@@ -1,43 +1,42 @@
 import axios from "axios";
 import { execSync } from "child_process";
-import fs from 'fs';
-import FormData from 'form-data';
+import fs from "fs";
+import FormData from "form-data";
 
 export async function deploy(appName: string, host: string) {
+  const tempHardcodedToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.p5Csu2THYW5zJys2CWdbGM8GaWjpY6lOQpdLoP4D7V4";
+  try {
+    const register = await axios.post(
+      `http://${host}:8080/application/register`,
+      {
+        name: appName,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: tempHardcodedToken,
+        },
+      }
+    );
+    const uuid = register.data as string;
+    execSync(`mkdir -p operon_deploy`);
+    execSync(`envsubst < operon-config.yaml > operon_deploy/operon-config.yaml`);
+    execSync(`zip -ry operon_deploy/${uuid}.zip ./* -x operon_deploy/* operon-config.yaml`);
+    execSync(`zip -j operon_deploy/${uuid}.zip operon_deploy/operon-config.yaml`);
 
-    const tempHardcodedToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.p5Csu2THYW5zJys2CWdbGM8GaWjpY6lOQpdLoP4D7V4";
-    try {
-        const register = await axios.post(
-            `http://${host}:8080/application/register`,
-            {
-                name: appName,
-            },
-            {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': tempHardcodedToken,
-                },
-            },
-        );
-        const uuid = register.data as string;
-        execSync(`mkdir -p operon_deploy`);
-        execSync(`envsubst < operon-config.yaml > operon_deploy/operon-config.yaml`);
-        execSync(`zip -ry operon_deploy/${uuid}.zip ./* -x operon_deploy/* operon-config.yaml`);
-        execSync(`zip -j operon_deploy/${uuid}.zip operon_deploy/operon-config.yaml`);
+    const formData = new FormData();
+    formData.append("app_archive", fs.createReadStream(`operon_deploy/${uuid}.zip`));
 
-        const formData = new FormData();
-        formData.append('app_archive', fs.createReadStream(`operon_deploy/${uuid}.zip`));
-
-        await axios.post(`http://${host}:8080/application/${uuid}`, formData, {
-            headers: {
-                ...formData.getHeaders(),
-                'Authorization': tempHardcodedToken,
-            },
-        });
-        console.log(`Successfully deployed: ${appName}`);
-        console.log(`${appName} ID: ${uuid}`)
-    } catch (e) {
-        console.log(`Deploying ${appName} failed`);
-        throw e;
-    }
+    await axios.post(`http://${host}:8080/application/${uuid}`, formData, {
+      headers: {
+        ...formData.getHeaders(),
+        Authorization: tempHardcodedToken,
+      },
+    });
+    console.log(`Successfully deployed: ${appName}`);
+    console.log(`${appName} ID: ${uuid}`);
+  } catch (e) {
+    console.log(`Deploying ${appName} failed`);
+    throw e;
+  }
 }

--- a/src/operon-runtime/deploy.ts
+++ b/src/operon-runtime/deploy.ts
@@ -2,9 +2,12 @@ import axios from "axios";
 import { execSync } from "child_process";
 import fs from "fs";
 import FormData from "form-data";
+import { operonEnvPath } from "./login";
 
 export async function deploy(appName: string, host: string) {
-  const tempHardcodedToken = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJKb2huIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.p5Csu2THYW5zJys2CWdbGM8GaWjpY6lOQpdLoP4D7V4";
+  let userToken = fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8");
+  userToken = userToken.replace(/\r|\n/g, ''); // Trim the trailing /r /n.
+  const bearerToken = "Bearer " + userToken;
   try {
     const register = await axios.post(
       `http://${host}:8080/application/register`,
@@ -14,7 +17,7 @@ export async function deploy(appName: string, host: string) {
       {
         headers: {
           "Content-Type": "application/json",
-          Authorization: tempHardcodedToken,
+          Authorization: bearerToken,
         },
       }
     );
@@ -30,7 +33,7 @@ export async function deploy(appName: string, host: string) {
     await axios.post(`http://${host}:8080/application/${uuid}`, formData, {
       headers: {
         ...formData.getHeaders(),
-        Authorization: tempHardcodedToken,
+        Authorization: bearerToken,
       },
     });
     console.log(`Successfully deployed: ${appName}`);

--- a/src/operon-runtime/deploy.ts
+++ b/src/operon-runtime/deploy.ts
@@ -24,8 +24,8 @@ export async function deploy(appName: string, host: string) {
     const uuid = register.data as string;
     execSync(`mkdir -p operon_deploy`);
     execSync(`envsubst < operon-config.yaml > operon_deploy/operon-config.yaml`);
-    execSync(`zip -ry operon_deploy/${uuid}.zip ./* -x operon_deploy/* operon-config.yaml`);
-    execSync(`zip -j operon_deploy/${uuid}.zip operon_deploy/operon-config.yaml`);
+    execSync(`zip -ry operon_deploy/${uuid}.zip ./* -x operon_deploy/* operon-config.yaml > /dev/null`);
+    execSync(`zip -j operon_deploy/${uuid}.zip operon_deploy/operon-config.yaml > /dev/null`);
 
     const formData = new FormData();
     formData.append("app_archive", fs.createReadStream(`operon_deploy/${uuid}.zip`));

--- a/src/operon-runtime/login.ts
+++ b/src/operon-runtime/login.ts
@@ -1,8 +1,9 @@
 import { execSync } from "child_process";
 import { TAlgorithm, encode } from "jwt-simple";
 import { createGlobalLogger } from "../telemetry/logs";
+import fs from "fs";
 
-const operonEnvPath = ".operon";
+export const operonEnvPath = ".operon";
 const secretKey = "SOME SECRET";
 
 interface Session {
@@ -35,7 +36,7 @@ export function login (userName: string) {
   const token = encode(session, secretKey, algorithm);
 
   execSync(`mkdir -p ${operonEnvPath}`);
-  execSync(`echo ${token} > ${operonEnvPath}/credentials`);
+  fs.writeFileSync(`${operonEnvPath}/credentials`, token, "utf-8");
 
   logger.info(`Successfully logged in as user: ${userName}`);
   logger.info(`You can view your credentials in: ./${operonEnvPath}/credentials`);

--- a/src/operon-runtime/login.ts
+++ b/src/operon-runtime/login.ts
@@ -1,15 +1,42 @@
 import { execSync } from "child_process";
+import { TAlgorithm, encode } from "jwt-simple";
+import { createGlobalLogger } from "../telemetry/logs";
 
 const operonEnvPath = ".operon";
+const secretKey = "SOME SECRET";
 
-export async function login (userName: string) {
+interface Session {
+  id: number;
+  dateCreated: number;
+  username: string;
+  issued: number;
+  expires: number;
+}
+
+
+export function login (userName: string) {
+  const logger = createGlobalLogger();
   // TODO: in the future, we should integrate with Okta for login.
   // Generate a valid JWT token based on the userName and store it in the `./.operon/credentials` file.
   // Then the deploy command can retrieve the token from this file.
-  console.log("Logging in as user: ", userName);
+  logger.info(`Logging in as user: ${userName}`);
+
+  const algorithm: TAlgorithm = "HS256";
+  const issued = Date.now();
+  const expires = issued + 1000; // Expires after 1 sec.
+  const session: Session = {
+    id: 1,
+    dateCreated: Date.now(),
+    username: userName,
+    issued: issued,
+    expires: expires
+  };
+
+  const token = encode(session, secretKey, algorithm);
 
   execSync(`mkdir -p ${operonEnvPath}`);
-  execSync(`echo ${userName} > ${operonEnvPath}/credentials`);
+  execSync(`echo ${token} > ${operonEnvPath}/credentials`);
 
-  console.log("Successfully logged in as user:", userName);
+  logger.info(`Successfully logged in as user: ${userName}`);
+  logger.info(`You can view your credentials in: ./${operonEnvPath}/credentials`);
 }

--- a/src/operon-runtime/login.ts
+++ b/src/operon-runtime/login.ts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+
+const operonEnvPath = ".operon";
+
+export async function login (userName: string) {
+  // TODO: in the future, we should integrate with Okta for login.
+  // Generate a valid JWT token based on the userName and store it in the `./.operon/credentials` file.
+  // Then the deploy command can retrieve the token from this file.
+  console.log("Logging in as user: ", userName);
+
+  execSync(`mkdir -p ${operonEnvPath}`);
+  execSync(`echo ${userName} > ${operonEnvPath}/credentials`);
+
+  console.log("Successfully logged in as user:", userName);
+}


### PR DESCRIPTION
This PR implements `npx operon login -u <username>`, which currently takes in a user name and creates a "valid but fake" JWT token to be used in `npx operon deploy`. This PR removes the previously hard coded JWT token in deploy.

`login` stores the generated token in a local file `.operon/credentials`, and `deploy` reads the token from that file.
In the future, we will integrate with a 3rd-party auth system (e.g., Okta) and we will re-direct users to login through the auth system and obtain a real JWT token there.