### PR TITLE
update login & deploy CLI to use usernames

### DIFF
--- a/src/cloud-cli/deploy.ts
+++ b/src/cloud-cli/deploy.ts
@@ -44,7 +44,7 @@ export async function deploy(appName: string, host: string) {
     if (axios.isAxiosError(e)) {
       console.error(`failed to deploy application ${appName}: ${e.response?.data}`);
     } else {
-      console.error(`failed to deploy application ${appName}`);
+      console.error(`failed to deploy application ${appName}: ${(e as Error).message}`);
     }
   }
 }

--- a/src/cloud-cli/deploy.ts
+++ b/src/cloud-cli/deploy.ts
@@ -2,15 +2,17 @@ import axios from "axios";
 import { execSync } from "child_process";
 import fs from "fs";
 import FormData from "form-data";
-import { operonEnvPath } from "./login";
+import { OperonCloudCredentials, operonEnvPath } from "./login";
 
 export async function deploy(appName: string, host: string) {
-  let userToken = fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8");
-  userToken = userToken.replace(/\r|\n/g, ''); // Trim the trailing /r /n.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
+  const userName = userCredentials.userName;
+  const userToken = userCredentials.token.replace(/\r|\n/g, ''); // Trim the trailing /r /n.
   const bearerToken = "Bearer " + userToken;
   try {
-    const register = await axios.post(
-      `http://${host}:8080/application/register`,
+    const register = await axios.put(
+      `http://${host}:8080/${userName}/application`,
       {
         name: appName,
       },
@@ -30,7 +32,7 @@ export async function deploy(appName: string, host: string) {
     const formData = new FormData();
     formData.append("app_archive", fs.createReadStream(`operon_deploy/${uuid}.zip`));
 
-    await axios.post(`http://${host}:8080/application/${uuid}`, formData, {
+    await axios.post(`http://${host}:8080/${userName}/application/${appName}`, formData, {
       headers: {
         ...formData.getHeaders(),
         Authorization: bearerToken,
@@ -39,7 +41,10 @@ export async function deploy(appName: string, host: string) {
     console.log(`Successfully deployed: ${appName}`);
     console.log(`${appName} ID: ${uuid}`);
   } catch (e) {
-    console.log(`Deploying ${appName} failed`);
-    throw e;
+    if (axios.isAxiosError(e)) {
+      console.error(`failed to deploy application ${appName}: ${e.response?.data}`);
+    } else {
+      console.error(`failed to deploy application ${appName}`);
+    }
   }
 }

--- a/src/cloud-cli/deploy.ts
+++ b/src/cloud-cli/deploy.ts
@@ -2,9 +2,12 @@ import axios from "axios";
 import { execSync } from "child_process";
 import fs from "fs";
 import FormData from "form-data";
+import { createGlobalLogger } from "../telemetry/logs";
 import { OperonCloudCredentials, operonEnvPath } from "./login";
 
 export async function deploy(appName: string, host: string) {
+  const logger = createGlobalLogger();
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
   const userName = userCredentials.userName;
@@ -38,13 +41,13 @@ export async function deploy(appName: string, host: string) {
         Authorization: bearerToken,
       },
     });
-    console.log(`Successfully deployed: ${appName}`);
-    console.log(`${appName} ID: ${uuid}`);
+    logger.info(`Successfully deployed: ${appName}`);
+    logger.info(`${appName} ID: ${uuid}`);
   } catch (e) {
     if (axios.isAxiosError(e)) {
-      console.error(`failed to deploy application ${appName}: ${e.response?.data}`);
+      logger.error(`failed to deploy application ${appName}: ${e.response?.data}`);
     } else {
-      console.error(`failed to deploy application ${appName}: ${(e as Error).message}`);
+      logger.error(`failed to deploy application ${appName}: ${(e as Error).message}`);
     }
   }
 }

--- a/src/cloud-cli/login.ts
+++ b/src/cloud-cli/login.ts
@@ -6,6 +6,11 @@ import fs from "fs";
 export const operonEnvPath = ".operon";
 const secretKey = "SOME SECRET";
 
+export interface OperonCloudCredentials {
+	token: string;
+	userName: string;
+}
+
 interface Session {
   id: number;
   dateCreated: number;
@@ -13,7 +18,6 @@ interface Session {
   issued: number;
   expires: number;
 }
-
 
 export function login (userName: string) {
   const logger = createGlobalLogger();
@@ -35,8 +39,13 @@ export function login (userName: string) {
 
   const token = encode(session, secretKey, algorithm);
 
+  const credentials: OperonCloudCredentials = {
+    token,
+    userName,
+  }
+
   execSync(`mkdir -p ${operonEnvPath}`);
-  fs.writeFileSync(`${operonEnvPath}/credentials`, token, "utf-8");
+  fs.writeFileSync(`${operonEnvPath}/credentials`, JSON.stringify(credentials), "utf-8");
 
   logger.info(`Successfully logged in as user: ${userName}`);
   logger.info(`You can view your credentials in: ./${operonEnvPath}/credentials`);


### PR DESCRIPTION
Depends on https://github.com/dbos-inc/operon-cloud/pull/40

This PR:
- Adds the username to the `.operon/credentials` file
- Uses said username to register applications & deploy code.
- Offers slightly cleaner Axios error handling

Tested:
![Screenshot 2023-10-20 at 16 32 06](https://github.com/dbos-inc/operon/assets/3437048/be14b467-90eb-4736-8e73-346b9066b752)
