### PR TITLE
Database access to middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,8 @@
         "yaml": "^2.3.1"
       },
       "bin": {
-        "operon": "dist/src/operon-runtime/cli.js"
+        "operon": "dist/src/operon-runtime/cli.js",
+        "operon-cloud": "dist/src/cloud-cli/cli.js"
       },
       "devDependencies": {
         "@prisma/client": "^5.3.1",

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -26,7 +26,7 @@ export interface MiddlewareContext {
 
   getConfig<T>(key: string, deflt: T | undefined) : T | undefined;
 
-  query<C extends UserDatabaseClient, R, T extends unknown[]>(qry: (dbclient: C, args: T) => Promise<R>, args: T): Promise<R>;
+  query<C extends UserDatabaseClient, R, T extends unknown[]>(qry: (dbclient: C, ...args: T) => Promise<R>, ...args: T): Promise<R>;
 }
 
 /**

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -2,13 +2,27 @@ import Koa from "koa";
 import { OperonClassRegistration, OperonRegistrationDefaults, getOrCreateOperonClassRegistration } from "../decorators";
 import { OperonUndefinedDecoratorInputError } from "../error";
 
-// Middleware context does not extend Operon context because it runs before actual Operon operations.
-export class MiddlewareContext {
+import { Span } from "@opentelemetry/sdk-trace-base";
+import { Logger as OperonLogger } from "../telemetry/logs";
+
+export class MiddlewareCtx {
   constructor(
     readonly koaContext: Koa.Context,
     readonly name: string, // Method (handler, transaction, workflow) name
     readonly requiredRole: string[], // Roles required for the invoked Operon operation, if empty perhaps auth is not required
   ) { }
+}
+
+// Middleware context does not extend Operon context because it runs before actual Operon operations.
+export interface MiddlewareContext {
+  readonly koaContext: Koa.Context;
+  readonly name: string; // Method (handler, transaction, workflow) name
+  readonly requiredRole: string[]; // Roles required for the invoked Operon operation, if empty perhaps auth is not required
+
+  readonly logger: OperonLogger;
+  readonly span: Span;
+
+  getConfig<T>(key: string, deflt: T | undefined) : T | undefined;
 }
 
 /**

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -7,24 +7,16 @@ import { UserDatabaseClient } from "../user_database";
 import { Span } from "@opentelemetry/sdk-trace-base";
 import { Logger as OperonLogger } from "../telemetry/logs";
 
-export class MiddlewareCtx {
-  constructor(
-    readonly koaContext: Koa.Context,
-    readonly name: string, // Method (handler, transaction, workflow) name
-    readonly requiredRole: string[], // Roles required for the invoked Operon operation, if empty perhaps auth is not required
-  ) { }
-}
-
 // Middleware context does not extend Operon context because it runs before actual Operon operations.
 export interface MiddlewareContext {
   readonly koaContext: Koa.Context;
   readonly name: string; // Method (handler, transaction, workflow) name
   readonly requiredRole: string[]; // Roles required for the invoked Operon operation, if empty perhaps auth is not required
 
-  readonly logger: OperonLogger;
-  readonly span: Span;
+  readonly logger: OperonLogger; // Logger, for logging from middleware
+  readonly span: Span; // Existing span
 
-  getConfig<T>(key: string, deflt: T | undefined) : T | undefined;
+  getConfig<T>(key: string, deflt: T | undefined) : T | undefined; // Access to configuration information
 
   query<C extends UserDatabaseClient, R, T extends unknown[]>(qry: (dbclient: C, ...args: T) => Promise<R>, ...args: T): Promise<R>;
 }

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -2,6 +2,8 @@ import Koa from "koa";
 import { OperonClassRegistration, OperonRegistrationDefaults, getOrCreateOperonClassRegistration } from "../decorators";
 import { OperonUndefinedDecoratorInputError } from "../error";
 
+import { UserDatabaseClient } from "../user_database";
+
 import { Span } from "@opentelemetry/sdk-trace-base";
 import { Logger as OperonLogger } from "../telemetry/logs";
 
@@ -23,6 +25,8 @@ export interface MiddlewareContext {
   readonly span: Span;
 
   getConfig<T>(key: string, deflt: T | undefined) : T | undefined;
+
+  query<C extends UserDatabaseClient, R, T extends unknown[]>(qry: (dbclient: C, args: T) => Promise<R>, args: T): Promise<R>;
 }
 
 /**

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -93,7 +93,11 @@ export class OperonHttpServer {
           try {
             // Check for auth first
             if (defaults?.authMiddleware) {
-              const res = await defaults.authMiddleware({name: ro.name, requiredRole: ro.getRequiredRoles(), koaContext: koaCtxt});
+              const res = await defaults.authMiddleware({
+                name: ro.name, requiredRole: ro.getRequiredRoles(), koaContext: koaCtxt,
+                logger: oc.logger, span: oc.span,
+                getConfig: (key:string, def)=>{return oc.getConfig(key, def);}
+              });
               if (res) {
                 oc.authenticatedUser = res.authenticatedUser;
                 oc.authenticatedRoles = res.authenticatedRoles;

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -97,7 +97,7 @@ export class OperonHttpServer {
                 name: ro.name, requiredRole: ro.getRequiredRoles(), koaContext: koaCtxt,
                 logger: oc.logger, span: oc.span,
                 getConfig: (key:string, def)=>{return oc.getConfig(key, def);},
-                query: (qry, ...args) => {return operon.userDatabase.queryFunction(qry, ...args);}
+                query: (query, ...args) => {return operon.userDatabase.queryFunction(query, ...args);}
               });
               if (res) {
                 oc.authenticatedUser = res.authenticatedUser;

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -96,7 +96,8 @@ export class OperonHttpServer {
               const res = await defaults.authMiddleware({
                 name: ro.name, requiredRole: ro.getRequiredRoles(), koaContext: koaCtxt,
                 logger: oc.logger, span: oc.span,
-                getConfig: (key:string, def)=>{return oc.getConfig(key, def);}
+                getConfig: (key:string, def)=>{return oc.getConfig(key, def);},
+                query: (qry, args) => {return operon.userDatabase.queryFunction(qry, args);}
               });
               if (res) {
                 oc.authenticatedUser = res.authenticatedUser;

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -97,7 +97,7 @@ export class OperonHttpServer {
                 name: ro.name, requiredRole: ro.getRequiredRoles(), koaContext: koaCtxt,
                 logger: oc.logger, span: oc.span,
                 getConfig: (key:string, def)=>{return oc.getConfig(key, def);},
-                query: (qry, args) => {return operon.userDatabase.queryFunction(qry, args);}
+                query: (qry, ...args) => {return operon.userDatabase.queryFunction(qry, ...args);}
               });
               if (res) {
                 oc.authenticatedUser = res.authenticatedUser;

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -89,7 +89,14 @@ export class PGNodeUserDatabase implements UserDatabase {
 
   async queryFunction<C extends UserDatabaseClient, R, T extends unknown[]>(func: UserDatabaseQuery<C, R, T>, ...args: T): Promise<R> {
     const client: PoolClient = await this.pool.connect();
-    return func(client as C, ...args);
+    try
+    {
+       return func(client as C, ...args);
+    }
+    finally
+    {
+      client.release();
+    }
   }
 
   async query<R, T extends unknown[]>(sql: string, ...params: T): Promise<R[]> {
@@ -197,11 +204,7 @@ export class PrismaUserDatabase implements UserDatabase {
   }
 
   async queryFunction<C extends UserDatabaseClient, R, T extends unknown[]>(func: UserDatabaseQuery<C, R, T>, ...args: T): Promise<R> {
-    return this.prisma.$transaction<R>(
-      async (q) => {
-        return await func(q as C, ...args);
-      }
-    );
+    return func(this.prisma as C, ...args);
   }
 
   async query<R, T extends unknown[]>(sql: string, ...params: T): Promise<R[]> {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -22,6 +22,7 @@ export function generateOperonTestConfig(dbClient?: UserDatabaseName): OperonCon
     },
     application: {
       counter: 3,
+      shouldExist: 'exists',
     },
     telemetry: {
       logs: {

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -1,4 +1,16 @@
-import {OperonTestingRuntime, OperonTransaction, OperonWorkflow, TransactionContext, WorkflowContext } from "../src";
+import request from "supertest";
+
+import {
+  OperonTestingRuntime, OperonTransaction, OperonWorkflow,
+  TransactionContext, WorkflowContext,
+  GetApi, PostApi,
+  HandlerContext,
+  RequiredRole, Authentication,
+  MiddlewareContext,
+} from "../src";
+import {
+  OperonNotAuthorizedError
+} from "../src/error"
 import { OperonConfig } from "../src/operon";
 import { UserDatabaseName } from "../src/user_database";
 import { TestKvTable, generateOperonTestConfig, setupOperonTestDb } from "./helpers";
@@ -94,5 +106,90 @@ describe("knex-tests", () => {
       const err: DatabaseError = e as DatabaseError;
       expect(err.code).toBe("23505");
     }
+  });
+});
+
+const userTableName = 'operon_test_user';
+interface UserTable
+{
+  id ?: number;
+  username ?: string;
+}
+
+@Authentication(KUserManager.authMiddlware)
+class KUserManager {
+  @OperonTransaction()
+  @PostApi('/register')
+  static async createUser(txnCtxt: KnexTransactionContext, uname: string) {
+    const result = await txnCtxt.client<UserTable>(userTableName).insert({username: uname}).returning("id");
+    return result;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @GetApi('/hello')
+  @RequiredRole(['user'])
+  static async hello(hCtxt: HandlerContext) {
+    return {messge: "hello "+hCtxt.authenticatedUser};
+  }
+
+  static async authMiddlware(ctx: MiddlewareContext) {
+    if (!ctx.requiredRole || !ctx.requiredRole.length) {
+      return;
+    }
+    const {user} = ctx.koaContext.query;
+    if (!user) {
+      throw new OperonNotAuthorizedError("User not provided", 401);
+    }
+    const u = await ctx.query(
+      (dbClient: Knex, uname: string) => {
+        return dbClient<UserTable>(userTableName).select("username").where({ username: uname })
+      }, user as string
+      );
+
+    if (!u || !u.length) {
+      throw new OperonNotAuthorizedError("User does not exist", 403);
+    }
+    ctx.logger.info(`Allowed in user: ${u[0].username}`);
+    return {
+      authenticatedUser: u[0].username!,
+      authenticatedRoles: ["user"],
+    };
+  }
+}
+
+describe("knex-auth-tests", () => {
+  let config: OperonConfig;
+  let testRuntime: OperonTestingRuntime;
+
+  beforeAll(async () => {
+    config = generateOperonTestConfig(UserDatabaseName.KNEX);
+    await setupOperonTestDb(config);
+  });
+
+  beforeEach(async () => {
+    testRuntime = await createInternalTestRuntime([KUserManager], config);
+    await testRuntime.queryUserDB(`DROP TABLE IF EXISTS ${userTableName};`);
+    await testRuntime.queryUserDB(`CREATE TABLE IF NOT EXISTS ${userTableName} (id SERIAL PRIMARY KEY, username TEXT);`);
+  });
+
+  afterEach(async () => {
+    await testRuntime.queryUserDB(`DROP TABLE IF EXISTS ${userTableName};`);
+    await testRuntime.destroy();
+  });
+
+  test("simple-knex-auth", async () => {
+    // No user name
+    const response1 = await request(testRuntime.getHandlersCallback()).get("/hello");
+    expect(response1.statusCode).toBe(401);
+
+    // User name doesn't exist
+    const response2 = await request(testRuntime.getHandlersCallback()).get("/hello?user=paul");
+    expect(response2.statusCode).toBe(403);
+
+    const response3 = await request(testRuntime.getHandlersCallback()).post("/register").send({uname: "paul"});
+    expect(response3.statusCode).toBe(200);
+
+    const response4 = await request(testRuntime.getHandlersCallback()).get("/hello?user=paul");
+    expect(response4.statusCode).toBe(200);
   });
 });

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -14,3 +14,8 @@ model testkv {
   id           String @id
   value        String
 }
+
+model operon_test_user {
+  id           Int @id
+  username     String
+}

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -84,7 +84,7 @@ describe("typeorm-tests", () => {
   test("simple-typeorm", async () => {
     const workUUID = uuidv1();
     await expect(testRuntime.invoke(KVController, workUUID).testTxn("test", "value")).resolves.toBe("test");
-    await expect(testRuntime.invoke(KVController, workUUID).testTxn("test", "value")).resolves.toBe("test");    
+    await expect(testRuntime.invoke(KVController, workUUID).testTxn("test", "value")).resolves.toBe("test");
   });
 
   test("typeorm-duplicate-transaction", async () => {

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -163,6 +163,7 @@ class UserManager {
     if (!u) {
       throw new OperonNotAuthorizedError("User does not exist", 403);
     }
+    ctx.logger.info(`Allowed in user: ${u.username}`);
     return {
       authenticatedUser: u.username,
       authenticatedRoles: ["user"],

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -143,8 +143,12 @@ class UserManager {
   }
 
   static async authMiddlware(ctx: MiddlewareContext) {
+    const cfg = ctx.getConfig<string>("shouldExist", "does not exist");
+    if (cfg !== "exists") {
+      throw Error("Auth is misconfigured.");
+    }
     if (!ctx.requiredRole || !ctx.requiredRole.length) {
-        return;
+      return;
     }
     const {user} = ctx.koaContext.query;
     if (!user) {

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -1,12 +1,28 @@
 // import { PrismaClient, testkv } from "@prisma/client";
-import { EntityManager } from "typeorm";
+
+import request from "supertest";
+
+import { Entity, Column, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
+import { EntityManager, Unique } from "typeorm";
+
 import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
-import { OperonTestingRuntime, OperonTransaction, OrmEntities, TransactionContext } from "../src";
+import {
+   OperonTestingRuntime,
+   OperonTransaction,
+   OrmEntities,
+   TransactionContext,
+   Authentication,
+   MiddlewareContext,
+   GetApi,
+   HandlerContext,
+   RequiredRole,
+   PostApi,
+} from "../src";
 import { OperonConfig } from "../src/operon";
 import { v1 as uuidv1 } from "uuid";
 import { UserDatabaseName } from "../src/user_database";
-import { Entity, Column, PrimaryColumn } from "typeorm";
 import { createInternalTestRuntime } from "../src/testing/testing_runtime";
+import { OperonNotAuthorizedError } from "../src/error";
 
 /**
  * Funtions used in tests.
@@ -68,7 +84,7 @@ describe("typeorm-tests", () => {
   test("simple-typeorm", async () => {
     const workUUID = uuidv1();
     await expect(testRuntime.invoke(KVController, workUUID).testTxn("test", "value")).resolves.toBe("test");
-    await expect(testRuntime.invoke(KVController, workUUID).testTxn("test", "value")).resolves.toBe("test");
+    await expect(testRuntime.invoke(KVController, workUUID).testTxn("test", "value")).resolves.toBe("test");    
   });
 
   test("typeorm-duplicate-transaction", async () => {
@@ -94,5 +110,95 @@ describe("typeorm-tests", () => {
     expect((results[0] as PromiseFulfilledResult<string>).value).toBe("oaoovalue");
     expect((results[1] as PromiseFulfilledResult<string>).value).toBe("oaoovalue");
     expect(globalCnt).toBeGreaterThanOrEqual(1);
+  });
+});
+
+@Entity()
+@Unique("onlyone", ["username"])
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string | undefined = undefined;
+
+  @Column()
+  username: string = "user";
+}
+
+@OrmEntities([User])
+@Authentication(UserManager.authMiddlware)
+class UserManager {
+  @OperonTransaction()
+  @PostApi('/register')
+  static async createUser(txnCtxt: TestTransactionContext, uname: string) {
+    const u: User = new User();
+    u.username = uname;
+    const res = await txnCtxt.client.save(u);
+    return res;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @GetApi('/hello')
+  @RequiredRole(['user'])
+  static async hello(hCtxt: HandlerContext) {
+    return {messge: "hello "+hCtxt.authenticatedUser};
+  }
+
+  static async authMiddlware(ctx: MiddlewareContext) {
+    if (!ctx.requiredRole || !ctx.requiredRole.length) {
+        return;
+    }
+    const {user} = ctx.koaContext.query;
+    if (!user) {
+      throw new OperonNotAuthorizedError("User not provided", 401);
+    }
+    const u = await ctx.query(
+      (dbClient: EntityManager, uname: string) => {
+        return dbClient.findOneBy(User, {username: uname});
+      }, user as string
+      );
+
+    if (!u) {
+      throw new OperonNotAuthorizedError("User does not exist", 403);
+    }
+    return {
+      authenticatedUser: u.username,
+      authenticatedRoles: ["user"],
+    };
+  }
+}
+
+describe("typeorm-auth-tests", () => {
+  let config: OperonConfig;
+  let testRuntime: OperonTestingRuntime;
+
+  beforeAll(async () => {
+    config = generateOperonTestConfig(UserDatabaseName.TYPEORM);
+    await setupOperonTestDb(config);
+  });
+
+  beforeEach(async () => {
+    globalCnt = 0;
+    testRuntime = await createInternalTestRuntime([UserManager], config);
+    await testRuntime.dropUserSchema();
+    await testRuntime.createUserSchema();
+  });
+
+  afterEach(async () => {
+    await testRuntime.destroy();
+  });
+
+  test("simple-typeorm", async () => {
+    // No user name
+    const response1 = await request(testRuntime.getHandlersCallback()).get("/hello");
+    expect(response1.statusCode).toBe(401);
+
+    // User name doesn't exist
+    const response2 = await request(testRuntime.getHandlersCallback()).get("/hello?user=paul");
+    expect(response2.statusCode).toBe(403);
+
+    const response3 = await request(testRuntime.getHandlersCallback()).post("/register").send({uname: "paul"});
+    expect(response3.statusCode).toBe(200);
+
+    const response4 = await request(testRuntime.getHandlersCallback()).get("/hello?user=paul");
+    expect(response4.statusCode).toBe(200);
   });
 });

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -1,5 +1,3 @@
-// import { PrismaClient, testkv } from "@prisma/client";
-
 import request from "supertest";
 
 import { Entity, Column, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
@@ -191,7 +189,7 @@ describe("typeorm-auth-tests", () => {
     await testRuntime.destroy();
   });
 
-  test("simple-typeorm", async () => {
+  test("auth-typeorm", async () => {
     // No user name
     const response1 = await request(testRuntime.getHandlersCallback()).get("/hello");
     expect(response1.statusCode).toBe(401);


### PR DESCRIPTION
Provide additional functions for middleware, including database access, logging, and configuration information.

This revealed a need for a better client interface to queries, that was more in line with the experience expected for those clients.  I have stubbed these in, except for Prisma (currently using transaction unnecessarily).

This needs considerably more test coverage, but you can see a test for TypeORM to get an idea of what is going on.
