### PR TITLE
Create an npm publish action

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,4 +1,4 @@
-name: Publish current branch to npm with a preview tag
+name: Publish current branch to npm
 
 on:
   workflow_dispatch:
@@ -29,7 +29,7 @@ jobs:
           stamp: package.json
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      - run: npm run lint
       - name: Publish release to npm
         uses: JS-DevTools/npm-publish@v3
         id: npmrelease

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -2,6 +2,11 @@ name: Publish current branch to npm with a preview tag
 
 on:
   workflow_dispatch:
+  pull_request:  ## For tests. Delete this before merging to main!
+    branches:
+      - main
+    types:
+      - synchronize
 
 jobs:
   publish:

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -2,11 +2,6 @@ name: Publish current branch to npm
 
 on:
   workflow_dispatch:
-  pull_request:  ## For tests. Delete this before merging to main!
-    branches:
-      - main
-    types:
-      - synchronize
 
 jobs:
   publish:
@@ -48,7 +43,7 @@ jobs:
           registry: https://registry.npmjs.org/
           tag: 'test'
       - if: ${{ steps.npmrelease.outputs.type }}
-        run: echo "Published a new release!"
+        run: echo "Published a new release package!"
       - if: ${{ steps.npmtest.outputs.type }}
-        run: echo "Published a new release!"
+        run: echo "Published a new test package!"
   

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -29,7 +29,6 @@ jobs:
           stamp: package.json
       - run: npm ci
       - run: npm run build
-      - run: npm run lint
       - name: Publish release to npm
         uses: JS-DevTools/npm-publish@v3
         id: npmrelease

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,0 +1,50 @@
+name: Publish current branch to npm with a preview tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 0 # fetch-depth 0 needed for NBGV
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Nerdbank.GitVersioning
+        id: nbgv
+        uses: dotnet/nbgv@v0.4.1
+        with:
+          stamp: package.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - name: Publish release to npm
+        uses: JS-DevTools/npm-publish@v3
+        id: npmrelease
+        # boolean properties from NBGV step appears to be converted into *capitalized* strings
+        # so explicitly string compare PublicRelease output value
+        if: ${{ steps.nbgv.outputs.PublicRelease == 'True'}}
+        with:
+          token: ${{ secrets.NPM_PUBLISH }}
+          registry: https://registry.npmjs.org/
+          tag: ${{ endsWith(steps.nbgv.outputs.NpmPackageVersion, steps.nbgv.outputs.PrereleaseVersion) && 'preview' || 'latest' }}  # Assign a 'preview' tag to versions end with '-preview'. Otherwise, assign a 'latest' tag to the latest release.
+      - name: Publish test package to npm
+        uses: JS-DevTools/npm-publish@v3
+        id: npmtest
+        if: ${{ steps.nbgv.outputs.PublicRelease == 'False'}}
+        with:
+          token: ${{ secrets.NPM_PUBLISH }}
+          registry: https://registry.npmjs.org/
+          tag: 'test'
+      - if: ${{ steps.npmrelease.outputs.type }}
+        run: echo "Published a new release!"
+      - if: ${{ steps.npmtest.outputs.type }}
+        run: echo "Published a new release!"
+  


### PR DESCRIPTION
This Github action publishes a package to npm with a proper tag:
- Only `release/*` branches will be tagged as `latest`.
- Main branch will be tagged as `preview`.
- Publishes from other branches will be tagged as `test`.

When we run `npm install @dbos-inc/operon` it will only install the latest release version, not the `preview` or `test` versions. Please the published versions here: https://www.npmjs.com/package/@dbos-inc/operon?activeTab=versions

This action currently can only be triggered manually.

Another cool thing about `JS-DevTools/npm-publish@v3` action is that it can automatically skip a publish if the version already exists on NPM. So we don't need to worry about version conflicts.