### PR TITLE
Cloud CLI Register & Delete

### DIFF
--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -39,9 +39,9 @@ program
   .requiredOption('-u, --userName <string>', 'User name', )
   .option('-h, --host <string>', 'Specify the host', 'localhost')
   .action(async (options: { userName: string, host: string }) => {
-    const succes = await registerUser(options.userName, options.host);
+    const success = await registerUser(options.userName, options.host);
     // Then, log in as the user.
-    if (succes) {
+    if (success) {
       login(options.userName);
     }
   });

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -39,9 +39,11 @@ program
   .requiredOption('-u, --userName <string>', 'User name', )
   .option('-h, --host <string>', 'Specify the host', 'localhost')
   .action(async (options: { userName: string, host: string }) => {
-    await registerUser(options.userName, options.host);
+    const succes = await registerUser(options.userName, options.host);
     // Then, log in as the user.
-    login(options.userName);
+    if (succes) {
+      login(options.userName);
+    }
   });
 
 program.parse(process.argv);

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -35,11 +35,13 @@ program
 
 program
   .command('register')
-  .description('Register a user in Operon cloud and log in')
+  .description('Register a user and log in Operon cloud')
   .requiredOption('-u, --userName <string>', 'User name', )
   .option('-h, --host <string>', 'Specify the host', 'localhost')
   .action(async (options: { userName: string, host: string }) => {
     await registerUser(options.userName, options.host);
+    // Then, log in as the user.
+    login(options.userName);
   });
 
 program.parse(process.argv);

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -4,6 +4,7 @@ import { deploy } from "./deploy";
 import { Command } from 'commander';
 import { login } from "./login";
 import { registerUser } from "./register";
+import { deleteApp } from "./delete";
 
 const program = new Command();
 
@@ -45,6 +46,16 @@ program
       login(options.userName);
     }
   });
+
+program
+  .command('delete')
+  .description('Delete a previously deployed application')
+  .requiredOption('-n, --name <string>', 'Specify the app name')
+  .option('-h, --host <string>', 'Specify the host', 'localhost')
+  .action(async (options: { name: string, host: string }) => {
+    await deleteApp(options.name, options.host);
+  });
+
 
 program.parse(process.argv);
 

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -3,6 +3,7 @@
 import { deploy } from "./deploy";
 import { Command } from 'commander';
 import { login } from "./login";
+import { registerUser } from "./register";
 
 const program = new Command();
 
@@ -26,14 +27,19 @@ program
 program
   .command('deploy')
   .description('Deploy an application to the cloud')
-  .option('-n, --name <string>', 'Specify the app name')
+  .requiredOption('-n, --name <string>', 'Specify the app name')
   .option('-h, --host <string>', 'Specify the host', 'localhost')
   .action(async (options: { name: string, host: string }) => {
-    if (!options.name) {
-      console.error('Error: the --name option is required.');
-      return;
-    }
     await deploy(options.name, options.host);
+  });
+
+program
+  .command('register')
+  .description('Register a user in Operon cloud and log in')
+  .requiredOption('-u, --userName <string>', 'User name', )
+  .option('-h, --host <string>', 'Specify the host', 'localhost')
+  .action(async (options: { userName: string, host: string }) => {
+    await registerUser(options.userName, options.host);
   });
 
 program.parse(process.argv);

--- a/src/cloud-cli/delete.ts
+++ b/src/cloud-cli/delete.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import fs from "fs";
+import { createGlobalLogger } from "../telemetry/logs";
+import { OperonCloudCredentials, operonEnvPath } from "./login";
+
+export async function deleteApp(appName: string, host: string) {
+  const logger = createGlobalLogger();
+
+  const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
+  const userName = userCredentials.userName;
+  const userToken = userCredentials.token.replace(/\r|\n/g, ""); // Trim the trailing /r /n.
+  const bearerToken = "Bearer " + userToken;
+
+  try {
+    await axios.delete(`http://${host}:8080/${userName}/application/${appName}`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: bearerToken,
+      },
+    });
+
+    logger.info(`Successfully deleted application: ${appName}`);
+  } catch (e) {
+    if (axios.isAxiosError(e) && e.response) {
+      logger.error(`failed to delete application ${appName}: ${e.response?.data}`);
+    } else {
+      logger.error(`failed to delete application ${appName}: ${(e as Error).message}`);
+    }
+  }
+}

--- a/src/cloud-cli/deploy.ts
+++ b/src/cloud-cli/deploy.ts
@@ -8,7 +8,6 @@ import { OperonCloudCredentials, operonEnvPath } from "./login";
 export async function deploy(appName: string, host: string) {
   const logger = createGlobalLogger();
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
   const userName = userCredentials.userName;
   const userToken = userCredentials.token.replace(/\r|\n/g, ''); // Trim the trailing /r /n.

--- a/src/cloud-cli/deploy.ts
+++ b/src/cloud-cli/deploy.ts
@@ -43,7 +43,7 @@ export async function deploy(appName: string, host: string) {
     logger.info(`Successfully deployed: ${appName}`);
     logger.info(`${appName} ID: ${uuid}`);
   } catch (e) {
-    if (axios.isAxiosError(e)) {
+    if (axios.isAxiosError(e) && e.response) {
       logger.error(`failed to deploy application ${appName}: ${e.response?.data}`);
     } else {
       logger.error(`failed to deploy application ${appName}: ${(e as Error).message}`);

--- a/src/cloud-cli/register.ts
+++ b/src/cloud-cli/register.ts
@@ -24,6 +24,7 @@ export async function registerUser(userName: string, host: string) {
     } else {
       logger.error(`failed to register user ${userName}: ${(e as Error).message}`);
     }
+    return false;
   }
   return true;
 }

--- a/src/cloud-cli/register.ts
+++ b/src/cloud-cli/register.ts
@@ -1,10 +1,8 @@
 import axios from "axios";
 import { createGlobalLogger } from "../telemetry/logs";
-import { login } from "./login";
 
 export async function registerUser(userName: string, host: string) {
   const logger = createGlobalLogger();
-
   try {
     // First, register the user.
     const register = await axios.put(
@@ -27,4 +25,5 @@ export async function registerUser(userName: string, host: string) {
       logger.error(`failed to register user ${userName}: ${(e as Error).message}`);
     }
   }
+  return true;
 }

--- a/src/cloud-cli/register.ts
+++ b/src/cloud-cli/register.ts
@@ -20,9 +20,6 @@ export async function registerUser(userName: string, host: string) {
     );
     const userUUID = register.data as string;
     logger.info(`Registered user ${userName}, UUID: ${userUUID}`);
-
-    // Then, log in as the user.
-    login(userName);
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
       logger.error(`failed to register user ${userName}: ${e.response.data}`);

--- a/src/cloud-cli/register.ts
+++ b/src/cloud-cli/register.ts
@@ -1,0 +1,33 @@
+import axios from "axios";
+import { createGlobalLogger } from "../telemetry/logs";
+import { login } from "./login";
+
+export async function registerUser(userName: string, host: string) {
+  const logger = createGlobalLogger();
+
+  try {
+    // First, register the user.
+    const register = await axios.put(
+      `http://${host}:8080/user`,
+      {
+        name: userName,
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+    const userUUID = register.data as string;
+    logger.info(`Registered user ${userName}, UUID: ${userUUID}`);
+
+    // Then, log in as the user.
+    login(userName);
+  } catch (e) {
+    if (axios.isAxiosError(e) && e.response) {
+      logger.error(`failed to register user ${userName}: ${e.response.data}`);
+    } else {
+      logger.error(`failed to register user ${userName}: ${(e as Error).message}`);
+    }
+  }
+}


### PR DESCRIPTION
This PR implements `npx operon-cloud register` and `npx operon-cloud delete` in the cloud CLI.
- Register currently sends a request to register a user in the control plane, and then log in as that user if registration succeeds. We will eventually redirect users to a 3rd-party registration/login page.
- Delete sends a request to delete a deployed application of a logged in user.

Tested on a bare-metal instance and it works well.