### PR TITLE
Set HTTP error message in typical way for OpenAPI

### DIFF
--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -176,11 +176,12 @@ export class OperonHttpServer {
                 st = 400;  // Set to 400: client-side error.
               }
               koaCtxt.status = st;
+              koaCtxt.message = e.message;
               koaCtxt.body = {
                 status: st,
                 message: e.message,
                 details: e,
-              }
+              };
             } else {
               // FIXME we should have a standard, user friendly message for errors that are not instances of Error.
               // using stringify() will not produce a pretty output, because our format function uses stringify() too.

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -108,7 +108,7 @@ describe("httpserver-tests", () => {
   test("response-error", async () => {
     const response = await request(testRuntime.getHandlersCallback()).get("/operon-error");
     expect(response.statusCode).toBe(503);
-    expect((response as any as Res).res.statusMessage).toBe("customize error");
+    expect((response as unknown as Res).res.statusMessage).toBe("customize error");
     expect(response.body.message).toBe("customize error");
     console.log(response);
   });

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -22,6 +22,7 @@ import { OperonConfig } from "../../src/operon";
 import { OperonNotAuthorizedError, OperonResponseError } from "../../src/error";
 import { PoolClient } from "pg";
 import { OperonTestingRuntime, OperonTestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+import { IncomingMessage } from "http";
 
 describe("httpserver-tests", () => {
   const testTableName = "operon_test_kv";
@@ -98,10 +99,18 @@ describe("httpserver-tests", () => {
     expect(response.text).toBe("hello 1");
   });
 
+  // This feels unclean, but supertest doesn't expose the error message the people we want. See:
+  //   https://github.com/ladjs/supertest/issues/95
+  interface Res {
+    res: IncomingMessage;
+  }
+
   test("response-error", async () => {
     const response = await request(testRuntime.getHandlersCallback()).get("/operon-error");
     expect(response.statusCode).toBe(503);
+    expect((response as any as Res).res.statusMessage).toBe("customize error");
     expect(response.body.message).toBe("customize error");
+    console.log(response);
   });
 
   test("datavalidation-error", async () => {


### PR DESCRIPTION
This makes it possible for OpenAPI clients to get the custom error message from Operon errors in a typical way.
Took some work to convince supertest to do this.