### PR TITLE
Operon-cloud "logs" Command

### DIFF
--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -5,6 +5,7 @@ import { Command } from 'commander';
 import { login } from "./login";
 import { registerUser } from "./register";
 import { deleteApp } from "./delete";
+import { getAppLogs } from "./monitor";
 
 const program = new Command();
 
@@ -54,6 +55,15 @@ program
   .option('-h, --host <string>', 'Specify the host', 'localhost')
   .action(async (options: { name: string, host: string }) => {
     await deleteApp(options.name, options.host);
+  });
+
+program
+  .command('logs')
+  .description('Print the microVM logs of a deployed application')
+  .requiredOption('-n, --name <string>', 'Specify the app name')
+  .option('-h, --host <string>', 'Specify the host', 'localhost')
+  .action(async (options: { name: string, host: string }) => {
+    await getAppLogs(options.name, options.host);
   });
 
 

--- a/src/cloud-cli/delete.ts
+++ b/src/cloud-cli/delete.ts
@@ -1,18 +1,14 @@
 import axios from "axios";
-import fs from "fs";
 import { createGlobalLogger } from "../telemetry/logs";
-import { OperonCloudCredentials, operonEnvPath } from "./login";
+import { getCloudCredentials } from "./utils";
 
 export async function deleteApp(appName: string, host: string) {
   const logger = createGlobalLogger();
-
-  const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
-  const userName = userCredentials.userName;
-  const userToken = userCredentials.token.replace(/\r|\n/g, ""); // Trim the trailing /r /n.
-  const bearerToken = "Bearer " + userToken;
+  const userCredentials = getCloudCredentials();
+  const bearerToken = "Bearer " + userCredentials.token;
 
   try {
-    await axios.delete(`http://${host}:8080/${userName}/application/${appName}`, {
+    await axios.delete(`http://${host}:8080/${userCredentials.userName}/application/${appName}`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: bearerToken,

--- a/src/cloud-cli/monitor.ts
+++ b/src/cloud-cli/monitor.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+import fs from "fs";
+import { createGlobalLogger } from "../telemetry/logs";
+import { OperonCloudCredentials, operonEnvPath } from "./login";
+
+export async function getAppLogs(appName: string, host: string) {
+  const logger = createGlobalLogger();
+
+  const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
+  const userName = userCredentials.userName;
+  const userToken = userCredentials.token.replace(/\r|\n/g, ""); // Trim the trailing /r /n.
+  const bearerToken = "Bearer " + userToken;
+
+  try {
+    const res = await axios.get(`http://${host}:8080/${userName}/logs/application/${appName}`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: bearerToken,
+      },
+    });
+
+    logger.info(`Successfully retrieved logs of application: ${appName}`);
+    logger.info(res.data)
+  } catch (e) {
+    if (axios.isAxiosError(e) && e.response) {
+      logger.error(`failed to retrieve logs of application ${appName}: ${e.response?.data}`);
+    } else {
+      logger.error(`failed to retrieve logs of application ${appName}: ${(e as Error).message}`);
+    }
+  }
+}

--- a/src/cloud-cli/monitor.ts
+++ b/src/cloud-cli/monitor.ts
@@ -1,18 +1,14 @@
 import axios from "axios";
-import fs from "fs";
 import { createGlobalLogger } from "../telemetry/logs";
-import { OperonCloudCredentials, operonEnvPath } from "./login";
+import { getCloudCredentials } from "./utils";
 
 export async function getAppLogs(appName: string, host: string) {
   const logger = createGlobalLogger();
-
-  const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
-  const userName = userCredentials.userName;
-  const userToken = userCredentials.token.replace(/\r|\n/g, ""); // Trim the trailing /r /n.
-  const bearerToken = "Bearer " + userToken;
+  const userCredentials = getCloudCredentials();
+  const bearerToken = "Bearer " + userCredentials.token;
 
   try {
-    const res = await axios.get(`http://${host}:8080/${userName}/logs/application/${appName}`, {
+    const res = await axios.get(`http://${host}:8080/${userCredentials.userName}/logs/application/${appName}`, {
       headers: {
         "Content-Type": "application/json",
         Authorization: bearerToken,

--- a/src/cloud-cli/utils.ts
+++ b/src/cloud-cli/utils.ts
@@ -1,0 +1,10 @@
+import { OperonCloudCredentials, operonEnvPath } from "./login";
+import fs from "fs";
+
+export function getCloudCredentials(): OperonCloudCredentials {
+  const userCredentials = JSON.parse(fs.readFileSync(`./${operonEnvPath}/credentials`).toString("utf-8")) as OperonCloudCredentials;
+  return {
+    userName: userCredentials.userName,
+    token: userCredentials.token.replace(/\r|\n/g, ""), // Trim the trailing /r /n.
+  };
+}


### PR DESCRIPTION
This PR adds the `npx operon-cloud logs -n <appName>` command, which retrieves FC microVM logs from the cloud.

Manually tested on a bare-metal machine.