### PR TITLE
add optional parameter for Operon workflow UUID header

### DIFF
--- a/src/operon-runtime/openApi.ts
+++ b/src/operon-runtime/openApi.ts
@@ -89,6 +89,15 @@ export class OpenApiGenerator {
       .map(p => [p, this.getParamSource(p, verb)] as [ParameterInfo, ArgSources]);
 
     const parameters = this.generateParameters(sourcedParams);
+
+    // add optional parameter for Operon workflow UUID header
+    parameters.push({
+      name: 'operon-workflowuuid',
+      in: 'header',
+      required: false,
+      schema: { type: 'string' },
+    });
+
     const requestBody = this.generateRequestBody(sourcedParams);
     const response = this.generateResponse(method);
     if (!response) return;
@@ -154,8 +163,8 @@ export class OpenApiGenerator {
     }];
   }
 
-  generateParameters(sourcedParams: [ParameterInfo, ArgSources][]): OpenApi3.ParameterObject[] | undefined {
-    if (sourcedParams.length === 0) return undefined;
+  generateParameters(sourcedParams: [ParameterInfo, ArgSources][]): OpenApi3.ParameterObject[] {
+    if (sourcedParams.length === 0) return [];
     return sourcedParams
       // QUERY and URL parameters are specified in the Operation.parameters field
       .filter(([_, source]) => source === ArgSources.QUERY || source === ArgSources.URL)

--- a/tests/operon-runtime/openapi.test.ts
+++ b/tests/operon-runtime/openapi.test.ts
@@ -69,39 +69,47 @@ describe("OpenApiGenerator", () => {
 const helloExampleExpected = {
   "openapi": "3.0.3",
   "info": {
-      "title": "operon-hello",
-      "version": "0.0.1"
+    "title": "operon-hello",
+    "version": "0.0.1"
   },
   "paths": {
-      "/greeting/{user}": {
-          "get": {
-              "operationId": "helloTransaction",
-              "responses": {
-                  "200": {
-                      "description": "Ok",
-                      "content": {
-                          "application/json": {
-                              "schema": {
-                                  "type": "string"
-                              }
-                          }
-                      }
-                  }
-              },
-              "parameters": [
-                  {
-                      "name": "user",
-                      "in": "path",
-                      "required": true,
-                      "schema": {
-                          "type": "string"
-                      }
-                  }
-              ]
+    "/greeting/{user}": {
+      "get": {
+        "operationId": "helloTransaction",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
+        },
+        "parameters": [
+          {
+            "name": "user",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "operon-workflowuuid",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
       }
+    }
   },
   "components": {
-      "schemas": {}
+    "schemas": {}
   }
 };


### PR DESCRIPTION
@qianl15 reminded me that all HTTP handlers support an [optional `operon-workflowuuid` header](https://github.com/dbos-inc/operon/blob/devhawk/headerWorkflowUUID/src/httpServer/server.ts#L144) for idempotent requests. This PR adds an optional header parameter to every OpenAPI path operation:

```yaml
        - name: operon-workflowuuid
          in: header
          required: false
          schema:
            type: string
```

Theoretically, this name could collide with a parameter name in the user's code. Unlikely but possible. @qianl15 suggested reserving all identifiers starting with "operon" for our use. I haven't implemented that check yet, but I think it would be a reasonable idea. 
