### PR TITLE
Remove Envsubst Dependency (#161)

### DIFF
--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -24,9 +24,9 @@ describe("operon-config", () => {
       application:
         payments_url: 'http://somedomain.com/payment'
         foo: \${FOO}
-        bar: \$BAR
+        bar: \${BAR}
         nested:
-            baz: \$BAZ
+            baz: \${BAZ}
             a:
               - 1
               - 2


### PR DESCRIPTION
Remove the envsubst dependency from Operon. For now, replacing it with a regex matching ${VAR_NAME} style placeholders.