### PR TITLE
Selective Workflow Recovery

### DIFF
--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -8,6 +8,7 @@ export interface workflow_status {
   assumed_role: string;
   authenticated_roles: string;  // Serialized list of roles.
   request: string;  // Serialized HTTPRequest
+  executor_id: string;  // Set to "local" for local deployment, set to microVM ID for cloud deployment.
 }
 
 export interface notifications {
@@ -57,7 +58,8 @@ export const systemDBSchema = `
     authenticated_roles TEXT,
     request TEXT,
     output TEXT,
-    error TEXT
+    error TEXT,
+    executor_id TEXT
   );
 
   CREATE TABLE IF NOT EXISTS notifications (

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -18,7 +18,7 @@ interface WorkflowOutput<R> {
   authenticatedRoles: Array<string>;
   assumedRole: string;
   request: HTTPRequest;
-  executor_id: string; // Set to "local" for local deployment, set to microVM ID for cloud deployment.
+  executorID: string; // Set to "local" for local deployment, set to microVM ID for cloud deployment.
 }
 
 interface OperationOutput<R> {
@@ -157,9 +157,9 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     });
   }
 
-  async getPendingWorkflows(): Promise<string[]> {
+  async getPendingWorkflows(executorID: string): Promise<string[]> {
     const workflows = await this.workflowStatusDB.getRangeAll('', '\xff') as Array<[string, WorkflowOutput<unknown>]>;
-    return workflows.filter(i => i[1].status === StatusString.PENDING).map(i => i[0]);
+    return workflows.filter(i => (i[1].status === StatusString.PENDING && i[1].executorID === executorID)).map(i => i[0]);
   }
 
   async getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null> {

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -69,8 +69,16 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
       .withValueEncoding(fdb.encoders.json);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async init(): Promise<void> { }
+  async init(recreateSystemDB: boolean): Promise<void> {
+    if (recreateSystemDB) {
+      // Clean up tables.
+      await this.workflowEventsDB.clearRangeStartsWith("");
+      await this.operationOutputsDB.clearRangeStartsWith([]);
+      await this.notificationsDB.clearRangeStartsWith([]);
+      await this.workflowEventsDB.clearRangeStartsWith([]);
+      await this.workflowInputsDB.clearRangeStartsWith("");
+    }
+  }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async destroy(): Promise<void> {

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -24,7 +24,6 @@ import { OperonCommunicator } from '../communicator';
 
 export const OperonWorkflowUUIDHeader = "operon-workflowuuid";
 export const OperonWorkflowRecoveryUrl = "/operon-workflow-recovery"
-export const OperonWorkflowRecoveryArg = "ids"
 
 export class OperonHttpServer {
   readonly app: Koa;
@@ -36,11 +35,7 @@ export class OperonHttpServer {
    * @param operon User pass in an Operon instance.
    * TODO: maybe call operon.init() somewhere in this class?
    */
-  constructor(readonly operon: Operon, config : {
-    koa ?: Koa,
-    router ?: Router,
-  } = {})
-  {
+  constructor(readonly operon: Operon, config: { koa?: Koa; router?: Router } = {}) {
     if (!config.router) {
       config.router = new Router();
     }
@@ -76,35 +71,39 @@ export class OperonHttpServer {
 
   /**
    * Register workflow recovery endpoint.
+   * Receives a list of executor IDs and returns a list of workflowUUIDs.
    */
   static registerRecoveryEndpoint(operon: Operon, router: Router) {
     // Handler function that parses request for recovery.
     const recoveryHandler = async (koaCtxt: Koa.Context, koaNext: Koa.Next) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const executorIDs = koaCtxt.request.body[OperonWorkflowRecoveryArg] as string[];
+      const executorIDs = koaCtxt.request.body as string[];
       operon.logger.info("Recovering workflows for executors: " + executorIDs.toString());
       const recoverHandles = await operon.recoverPendingWorkflows(executorIDs);
       operon.recoveryWorkflowHandles.push(...recoverHandles);
+
+      // Return a list of workflowUUIDs being recovered.
+      koaCtxt.body = await Promise.allSettled(recoverHandles.map((i) => i.getWorkflowUUID())).then((results) =>
+        results.filter((i) => i.status === "fulfilled").map((i) => (i as PromiseFulfilledResult<unknown>).value)
+      );
       await koaNext();
-    }
+    };
 
     router.post(OperonWorkflowRecoveryUrl, recoveryHandler);
     operon.logger.debug(`Operon Server Registered Recovery POST ${OperonWorkflowRecoveryUrl}`);
-
   }
 
   /**
    * Register functions decorated with Operon decorators as HTTP endpoints.
    */
-  static registerDecoratedEndpoints(operon : Operon, router : Router)
-  {
+  static registerDecoratedEndpoints(operon: Operon, router: Router) {
     // Register user declared endpoints, wrap around the endpoint with request parsing and response.
     operon.registeredOperations.forEach((registeredOperation) => {
       const ro = registeredOperation as OperonHandlerRegistration<unknown, unknown[], unknown>;
       if (ro.apiURL) {
-        // Ignore URL with "/operon-workflow-recovery" prefix. 
+        // Ignore URL with "/operon-workflow-recovery" prefix.
         if (ro.apiURL.startsWith(OperonWorkflowRecoveryUrl)) {
-          operon.logger.error(`Invalid URL: ${ro.apiURL} -- should not start with ${OperonWorkflowRecoveryUrl}!`)
+          operon.logger.error(`Invalid URL: ${ro.apiURL} -- should not start with ${OperonWorkflowRecoveryUrl}!`);
           return;
         }
 
@@ -114,7 +113,7 @@ export class OperonHttpServer {
           defaults.koaMiddlewares.forEach((koaMiddleware) => {
             operon.logger.debug(`Operon Server applying middleware ${koaMiddleware.name} to ${ro.apiURL}`);
             router.use(ro.apiURL, koaMiddleware);
-          })
+          });
         }
 
         // Wrapper function that parses request and send response.
@@ -125,10 +124,17 @@ export class OperonHttpServer {
             // Check for auth first
             if (defaults?.authMiddleware) {
               const res = await defaults.authMiddleware({
-                name: ro.name, requiredRole: ro.getRequiredRoles(), koaContext: koaCtxt,
-                logger: oc.logger, span: oc.span,
-                getConfig: (key:string, def)=>{return oc.getConfig(key, def);},
-                query: (query, ...args) => {return operon.userDatabase.queryFunction(query, ...args);}
+                name: ro.name,
+                requiredRole: ro.getRequiredRoles(),
+                koaContext: koaCtxt,
+                logger: oc.logger,
+                span: oc.span,
+                getConfig: (key: string, def) => {
+                  return oc.getConfig(key, def);
+                },
+                query: (query, ...args) => {
+                  return operon.userDatabase.queryFunction(query, ...args);
+                },
               });
               if (res) {
                 oc.authenticatedUser = res.authenticatedUser;
@@ -139,7 +145,7 @@ export class OperonHttpServer {
             // Parse the arguments.
             const args: unknown[] = [];
             ro.args.forEach((marg, idx) => {
-              marg.argSource = marg.argSource ?? ArgSources.DEFAULT;  // Assign a default value.
+              marg.argSource = marg.argSource ?? ArgSources.DEFAULT; // Assign a default value.
               if (idx === 0) {
                 return; // Do not parse the context.
               }
@@ -201,10 +207,10 @@ export class OperonHttpServer {
             if (e instanceof Error) {
               oc.logger.error(e.message);
               oc.span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
-              let st = ((e as OperonResponseError)?.status || 500);
+              let st = (e as OperonResponseError)?.status || 500;
               const operonErrorCode = (e as OperonError)?.operonErrorCode;
               if (operonErrorCode && isOperonClientError(operonErrorCode)) {
-                st = 400;  // Set to 400: client-side error.
+                st = 400; // Set to 400: client-side error.
               }
               koaCtxt.status = st;
               koaCtxt.message = e.message;
@@ -237,10 +243,10 @@ export class OperonHttpServer {
               {
                 set: (carrier: Carrier, key: string, value: string) => {
                   carrier.context.set(key, value);
-                }
-              },
+                },
+              }
             );
-            operon.tracer.endSpan(oc.span)
+            operon.tracer.endSpan(oc.span);
             await koaNext();
           }
         };

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -391,8 +391,18 @@ export class Operon {
    * A recovery process that runs during Operon init time.
    * It runs to completion all pending workflows that were executing when the previous executor failed.
    */
-  async recoverPendingWorkflows() {
-    const pendingWorkflows = await this.systemDatabase.getPendingWorkflows();
+  async recoverPendingWorkflows(executorIDs?: string[]) {
+    if (!executorIDs) {
+      executorIDs = ["local"]  // For local deployment.
+    }
+
+    const pendingWorkflows: string[] = [];
+    for (const execID of executorIDs) {
+      this.logger.debug(`Recovering workflows of executor: ${execID}`)
+      const wIDs = await this.systemDatabase.getPendingWorkflows(execID)
+      pendingWorkflows.push(...wIDs);
+    }
+
     const handlerArray: WorkflowHandle<any>[] = [];
     for (const workflowUUID of pendingWorkflows) {
       try {

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -396,7 +396,7 @@ export class Operon {
    * It runs to completion all pending workflows that were executing when the previous executor failed.
    */
   async recoverPendingWorkflows(executorIDs?: string[]): Promise<WorkflowHandle<any>[]> {
-    if (!executorIDs) {
+    if (!executorIDs || executorIDs.length === 0) {
       executorIDs = ["local"]  // For local deployment.
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -21,7 +21,7 @@ export interface SystemDatabase {
   flushWorkflowStatusBuffer(): Promise<Array<string>>;
   recordWorkflowError(workflowUUID: string, error: Error): Promise<void>;
 
-  getPendingWorkflows(): Promise<Array<string>>;
+  getPendingWorkflows(executorID: string): Promise<Array<string>>;
   getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null>;
 
   checkOperationOutput<R>(workflowUUID: string, functionID: number): Promise<OperonNull | R>;
@@ -136,10 +136,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
   }
 
-  async getPendingWorkflows(): Promise<Array<string>> {
+  async getPendingWorkflows(executorID: string): Promise<Array<string>> {
     const { rows } = await this.pool.query<workflow_status>(
-      `SELECT workflow_uuid FROM workflow_status WHERE status=$1`,
-      [StatusString.PENDING]
+      `SELECT workflow_uuid FROM workflow_status WHERE status=$1 AND executor_id=$2`,
+      [StatusString.PENDING, executorID]
     )
     return rows.map(i => i.workflow_uuid);
   }

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -15,17 +15,20 @@ describe("foundationdb-recovery", () => {
 
   beforeEach(async () => {
     const systemDB: FoundationDBSystemDatabase = new FoundationDBSystemDatabase();
-    testRuntime = await createInternalTestRuntime([FailureRecovery], config, systemDB, true);
+    testRuntime = await createInternalTestRuntime([LocalRecovery, ExecutorRecovery], config, systemDB);
   });
 
   afterEach(async () => {
     await testRuntime.destroy();
   });
 
-  class FailureRecovery {
+  /**
+   * Test for the default local workflow recovery.
+   */
+  class LocalRecovery {
     static resolve1: () => void;
     static promise1 = new Promise<void>((resolve) => {
-      FailureRecovery.resolve1 = resolve;
+      LocalRecovery.resolve1 = resolve;
     });
 
     static cnt = 0;
@@ -33,26 +36,80 @@ describe("foundationdb-recovery", () => {
     @OperonWorkflow()
     static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
       if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
-        FailureRecovery.cnt += input;
+        LocalRecovery.cnt += input;
       }
-      await FailureRecovery.promise1;
+      await LocalRecovery.promise1;
       return ctxt.authenticatedUser;
     }
   }
 
-  test("failure-recovery", async () => {
+  test("local-recovery", async () => {
     // Run a workflow until pending and start recovery.
     const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
-    clearInterval(operon.flushBufferID); // Don't flush the output buffer.
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer, making sure the workflow is executed.
 
-    const handle = await testRuntime.invoke(FailureRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+    const handle = await testRuntime.invoke(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
 
     const recoverHandles = await operon.recoverPendingWorkflows();
-    FailureRecovery.resolve1();
+    LocalRecovery.resolve1();
 
     expect(recoverHandles.length).toBe(1);
     await expect(recoverHandles[0].getResult()).resolves.toBe("test_recovery_user");
     await expect(handle.getResult()).resolves.toBe("test_recovery_user");
-    expect(FailureRecovery.cnt).toBe(10); // Should run twice.
+    expect(LocalRecovery.cnt).toBe(10); // Should run twice.
+  });
+
+  /**
+   * Test for selectively recovering workflows run by an executor.
+   */
+  class ExecutorRecovery {
+    static resolve1: () => void;
+    static promise1 = new Promise<void>((resolve) => {
+      ExecutorRecovery.resolve1 = resolve;
+    });
+
+    static resolve2: () => void;
+    static promise2 = new Promise<void>((resolve) => {
+      ExecutorRecovery.resolve2 = resolve;
+    });
+
+    static localCnt = 0;
+    static executorCnt = 0;
+
+    @OperonWorkflow()
+    static async localWorkflow(ctxt: WorkflowContext, input: number) {
+      ExecutorRecovery.localCnt += input;
+      await ExecutorRecovery.promise1;
+      return ctxt.authenticatedUser;
+    }
+
+    @OperonWorkflow()
+    static async executorWorkflow(ctxt: WorkflowContext, input: number) {
+      ExecutorRecovery.executorCnt += input;
+      await ExecutorRecovery.promise2;
+      return ctxt.authenticatedUser;
+    }
+  }
+
+  test("selective-recovery", async () => {
+    // Invoke a workflow multiple times with different executor IDs, but only recover workflows for a specific executor.
+    const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer, making sure workflows are executed.
+
+    const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
+
+    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "operon-executorid": "fcvm123" } } }).executorWorkflow(5);
+
+    const recoverHandles = await operon.recoverPendingWorkflows(["fcvm123"]);
+    ExecutorRecovery.resolve1();
+    ExecutorRecovery.resolve2();
+
+    expect(recoverHandles.length).toBe(1);
+    await expect(recoverHandles[0].getResult()).resolves.toBe("cloud_user");
+    await expect(localHandle.getResult()).resolves.toBe("local_user");
+    await expect(execHandle.getResult()).resolves.toBe("cloud_user");
+
+    expect(ExecutorRecovery.localCnt).toBe(3); // Should run only once.
+    expect(ExecutorRecovery.executorCnt).toBe(10); // Should run twice.
   });
 });

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -33,7 +33,6 @@ describe("foundationdb-recovery", () => {
     @OperonWorkflow()
     static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
       if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
-        console.trace("Invoked! " + FailureRecovery.cnt + " " + input)
         FailureRecovery.cnt += input;
       }
       await FailureRecovery.promise1;

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -1,0 +1,59 @@
+import { WorkflowContext, OperonWorkflow, OperonTestingRuntime } from "../../src/";
+import { generateOperonTestConfig, setupOperonTestDb } from "../helpers";
+import { FoundationDBSystemDatabase } from "../../src/foundationdb/fdb_system_database";
+import { OperonConfig } from "../../src/operon";
+import { OperonTestingRuntimeImpl, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+
+describe("foundationdb-recovery", () => {
+  let config: OperonConfig;
+  let testRuntime: OperonTestingRuntime;
+
+  beforeAll(async () => {
+    config = generateOperonTestConfig();
+    await setupOperonTestDb(config);
+  });
+
+  beforeEach(async () => {
+    const systemDB: FoundationDBSystemDatabase = new FoundationDBSystemDatabase();
+    testRuntime = await createInternalTestRuntime([FailureRecovery], config, systemDB, true);
+  });
+
+  afterEach(async () => {
+    await testRuntime.destroy();
+  });
+
+  class FailureRecovery {
+    static resolve1: () => void;
+    static promise1 = new Promise<void>((resolve) => {
+      FailureRecovery.resolve1 = resolve;
+    });
+
+    static cnt = 0;
+
+    @OperonWorkflow()
+    static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
+      if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
+        console.trace("Invoked! " + FailureRecovery.cnt + " " + input)
+        FailureRecovery.cnt += input;
+      }
+      await FailureRecovery.promise1;
+      return ctxt.authenticatedUser;
+    }
+  }
+
+  test("failure-recovery", async () => {
+    // Run a workflow until pending and start recovery.
+    const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer.
+
+    const handle = await testRuntime.invoke(FailureRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+
+    const recoverHandles = await operon.recoverPendingWorkflows();
+    FailureRecovery.resolve1();
+
+    expect(recoverHandles.length).toBe(1);
+    await expect(recoverHandles[0].getResult()).resolves.toBe("test_recovery_user");
+    await expect(handle.getResult()).resolves.toBe("test_recovery_user");
+    expect(FailureRecovery.cnt).toBe(10); // Should run twice.
+  });
+});

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -31,6 +31,11 @@ describe("foundationdb-recovery", () => {
       LocalRecovery.resolve1 = resolve;
     });
 
+    static resolve2: () => void;
+    static promise2 = new Promise<void>((resolve) => {
+      LocalRecovery.resolve2 = resolve;
+    });
+
     static cnt = 0;
 
     @OperonWorkflow()
@@ -38,6 +43,12 @@ describe("foundationdb-recovery", () => {
       if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
         LocalRecovery.cnt += input;
       }
+
+      // Signal the recovery is done.
+      if (LocalRecovery.cnt > input) {
+        LocalRecovery.resolve2();
+      }
+
       await LocalRecovery.promise1;
       return ctxt.authenticatedUser;
     }
@@ -46,12 +57,12 @@ describe("foundationdb-recovery", () => {
   test("local-recovery", async () => {
     // Run a workflow until pending and start recovery.
     const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
-    clearInterval(operon.flushBufferID); // Don't flush the output buffer, making sure the workflow is executed.
 
     const handle = await testRuntime.invoke(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
 
     const recoverHandles = await operon.recoverPendingWorkflows();
-    LocalRecovery.resolve1();
+    await LocalRecovery.promise2; // Wait for the recovery is done.
+    LocalRecovery.resolve1(); // Both can finish now.
 
     expect(recoverHandles.length).toBe(1);
     await expect(recoverHandles[0].getResult()).resolves.toBe("test_recovery_user");
@@ -63,6 +74,11 @@ describe("foundationdb-recovery", () => {
    * Test for selectively recovering workflows run by an executor.
    */
   class ExecutorRecovery {
+    static localResolve: () => void;
+    static localPromise = new Promise<void>((resolve) => {
+      ExecutorRecovery.localResolve = resolve;
+    });
+
     static resolve1: () => void;
     static promise1 = new Promise<void>((resolve) => {
       ExecutorRecovery.resolve1 = resolve;
@@ -79,14 +95,20 @@ describe("foundationdb-recovery", () => {
     @OperonWorkflow()
     static async localWorkflow(ctxt: WorkflowContext, input: number) {
       ExecutorRecovery.localCnt += input;
-      await ExecutorRecovery.promise1;
+      await ExecutorRecovery.localPromise;
       return ctxt.authenticatedUser;
     }
 
     @OperonWorkflow()
     static async executorWorkflow(ctxt: WorkflowContext, input: number) {
       ExecutorRecovery.executorCnt += input;
-      await ExecutorRecovery.promise2;
+
+      // Signal the recovery is done.
+      if (ExecutorRecovery.executorCnt > input) {
+        ExecutorRecovery.resolve2();
+      }
+
+      await ExecutorRecovery.promise1;
       return ctxt.authenticatedUser;
     }
   }
@@ -94,15 +116,15 @@ describe("foundationdb-recovery", () => {
   test("selective-recovery", async () => {
     // Invoke a workflow multiple times with different executor IDs, but only recover workflows for a specific executor.
     const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
-    clearInterval(operon.flushBufferID); // Don't flush the output buffer, making sure workflows are executed.
 
     const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
 
     const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "operon-executorid": "fcvm123" } } }).executorWorkflow(5);
 
     const recoverHandles = await operon.recoverPendingWorkflows(["fcvm123"]);
+    await ExecutorRecovery.promise2; // Wait for the recovery is done.
     ExecutorRecovery.resolve1();
-    ExecutorRecovery.resolve2();
+    ExecutorRecovery.localResolve();
 
     expect(recoverHandles.length).toBe(1);
     await expect(recoverHandles[0].getResult()).resolves.toBe("cloud_user");

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -110,7 +110,6 @@ describe("httpserver-tests", () => {
     expect(response.statusCode).toBe(503);
     expect((response as unknown as Res).res.statusMessage).toBe("customize error");
     expect(response.body.message).toBe("customize error");
-    console.log(response);
   });
 
   test("datavalidation-error", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -31,7 +31,6 @@ describe("recovery-tests", () => {
     @OperonWorkflow()
     static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
       if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
-        console.trace("Invoked! " + FailureRecovery.cnt + " " + input)
         FailureRecovery.cnt += input;
       }
       await FailureRecovery.promise1;

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -1,0 +1,57 @@
+import { WorkflowContext, OperonWorkflow, OperonTestingRuntime } from "../src/";
+import { generateOperonTestConfig, setupOperonTestDb,  } from "./helpers";
+import { OperonConfig } from "../src/operon";
+import { OperonTestingRuntimeImpl, createInternalTestRuntime } from "../src/testing/testing_runtime";
+
+describe("recovery-tests", () => {
+  let config: OperonConfig;
+  let testRuntime: OperonTestingRuntime;
+
+  beforeAll(async () => {
+    config = generateOperonTestConfig();
+    await setupOperonTestDb(config);
+  });
+
+  beforeEach(async () => {
+    testRuntime = await createInternalTestRuntime([FailureRecovery], config);
+  });
+
+  afterEach(async () => {
+    await testRuntime.destroy();
+  });
+
+  class FailureRecovery {
+    static resolve1: () => void;
+    static promise1 = new Promise<void>((resolve) => {
+      FailureRecovery.resolve1 = resolve;
+    });
+
+    static cnt = 0;
+
+    @OperonWorkflow()
+    static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
+      if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
+        console.trace("Invoked! " + FailureRecovery.cnt + " " + input)
+        FailureRecovery.cnt += input;
+      }
+      await FailureRecovery.promise1;
+      return ctxt.authenticatedUser;
+    }
+  }
+
+  test("failure-recovery", async () => {
+    // Run a workflow until pending and start recovery.
+    const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer.
+
+    const handle = await testRuntime.invoke(FailureRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+
+    const recoverHandles = await operon.recoverPendingWorkflows();
+    FailureRecovery.resolve1();
+
+    expect(recoverHandles.length).toBe(1);
+    await expect(recoverHandles[0].getResult()).resolves.toBe("test_recovery_user");
+    await expect(handle.getResult()).resolves.toBe("test_recovery_user");
+    expect(FailureRecovery.cnt).toBe(10); // Should run twice.
+  });
+});

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -1,5 +1,5 @@
 import { WorkflowContext, OperonWorkflow, OperonTestingRuntime } from "../src/";
-import { generateOperonTestConfig, setupOperonTestDb,  } from "./helpers";
+import { generateOperonTestConfig, setupOperonTestDb } from "./helpers";
 import { OperonConfig } from "../src/operon";
 import { OperonTestingRuntimeImpl, createInternalTestRuntime } from "../src/testing/testing_runtime";
 
@@ -13,17 +13,20 @@ describe("recovery-tests", () => {
   });
 
   beforeEach(async () => {
-    testRuntime = await createInternalTestRuntime([FailureRecovery], config);
+    testRuntime = await createInternalTestRuntime([LocalRecovery, ExecutorRecovery], config);
   });
 
   afterEach(async () => {
     await testRuntime.destroy();
   });
 
-  class FailureRecovery {
+  /**
+   * Test for the default local workflow recovery.
+   */
+  class LocalRecovery {
     static resolve1: () => void;
     static promise1 = new Promise<void>((resolve) => {
-      FailureRecovery.resolve1 = resolve;
+      LocalRecovery.resolve1 = resolve;
     });
 
     static cnt = 0;
@@ -31,26 +34,80 @@ describe("recovery-tests", () => {
     @OperonWorkflow()
     static async testRecoveryWorkflow(ctxt: WorkflowContext, input: number) {
       if (ctxt.authenticatedUser === "test_recovery_user" && ctxt.request.url === "test-recovery-url") {
-        FailureRecovery.cnt += input;
+        LocalRecovery.cnt += input;
       }
-      await FailureRecovery.promise1;
+      await LocalRecovery.promise1;
       return ctxt.authenticatedUser;
     }
   }
 
-  test("failure-recovery", async () => {
+  test("local-recovery", async () => {
     // Run a workflow until pending and start recovery.
     const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
-    clearInterval(operon.flushBufferID); // Don't flush the output buffer.
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer, making sure the workflow is executed.
 
-    const handle = await testRuntime.invoke(FailureRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+    const handle = await testRuntime.invoke(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
 
     const recoverHandles = await operon.recoverPendingWorkflows();
-    FailureRecovery.resolve1();
+    LocalRecovery.resolve1();
 
     expect(recoverHandles.length).toBe(1);
     await expect(recoverHandles[0].getResult()).resolves.toBe("test_recovery_user");
     await expect(handle.getResult()).resolves.toBe("test_recovery_user");
-    expect(FailureRecovery.cnt).toBe(10); // Should run twice.
+    expect(LocalRecovery.cnt).toBe(10); // Should run twice.
+  });
+
+  /**
+   * Test for selectively recovering workflows run by an executor.
+   */
+  class ExecutorRecovery {
+    static resolve1: () => void;
+    static promise1 = new Promise<void>((resolve) => {
+      ExecutorRecovery.resolve1 = resolve;
+    });
+
+    static resolve2: () => void;
+    static promise2 = new Promise<void>((resolve) => {
+      ExecutorRecovery.resolve2 = resolve;
+    });
+
+    static localCnt = 0;
+    static executorCnt = 0;
+
+    @OperonWorkflow()
+    static async localWorkflow(ctxt: WorkflowContext, input: number) {
+      ExecutorRecovery.localCnt += input;
+      await ExecutorRecovery.promise1;
+      return ctxt.authenticatedUser;
+    }
+
+    @OperonWorkflow()
+    static async executorWorkflow(ctxt: WorkflowContext, input: number) {
+      ExecutorRecovery.executorCnt += input;
+      await ExecutorRecovery.promise2;
+      return ctxt.authenticatedUser;
+    }
+  }
+
+  test("selective-recovery", async () => {
+    // Invoke a workflow multiple times with different executor IDs, but only recover workflows for a specific executor.
+    const operon = (testRuntime as OperonTestingRuntimeImpl).getOperon();
+    clearInterval(operon.flushBufferID); // Don't flush the output buffer, making sure workflows are executed.
+
+    const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
+
+    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user", request: { headers: { "operon-executorid": "fcvm123" } } }).executorWorkflow(5);
+
+    const recoverHandles = await operon.recoverPendingWorkflows(["fcvm123"]);
+    ExecutorRecovery.resolve1();
+    ExecutorRecovery.resolve2();
+
+    expect(recoverHandles.length).toBe(1);
+    await expect(recoverHandles[0].getResult()).resolves.toBe("cloud_user");
+    await expect(localHandle.getResult()).resolves.toBe("local_user");
+    await expect(execHandle.getResult()).resolves.toBe("cloud_user");
+
+    expect(ExecutorRecovery.localCnt).toBe(3); // Should run only once.
+    expect(ExecutorRecovery.executorCnt).toBe(10); // Should run twice.
   });
 });


### PR DESCRIPTION
This PR implements selective workflow recovery based on the `executorID`. Previously, Operon tries to recover all workflows with `PENDING` status, and also has a race condition bug where the recovery may interfere with normal executions.

This PR adds an `executor_id` field in the `workflow_status` table that records the ID of the machine that executes this workflow. The `executor_id` field by default is "local" if Operon is tested locally, and is set to the Firecracker VM ID if running on the cloud. We extract this ID from the `operon-executorid` HTTP reqeust header (will be automatically set by the cloud).

Then, we update the `recoverPendingWorkflows` method to accept a list of executor IDs and only recover workflows that belong to those executors.

We also add a reserved HTTP POST endpoint (`/operon-workflow-recovery`), which allows us to trigger workflow recovery externally from the cloud platform.