### PR TITLE
Update config loading function names to become compatible again with demo apps.

### DIFF
--- a/examples/hello/knexfile.ts
+++ b/examples/hello/knexfile.ts
@@ -1,10 +1,10 @@
 // knexfile.ts
 
 import { Knex } from 'knex';
-import { buildConfigs } from '@dbos-inc/operon/dist/src/operon-runtime/config'
+import { parseConfigFile } from '@dbos-inc/operon/dist/src/operon-runtime/config'
 import { OperonConfig } from '@dbos-inc/operon/dist/src/operon';
 
-const [operonConfig, ]: [OperonConfig, unknown] = buildConfigs();
+const [operonConfig, ]: [OperonConfig, unknown] = parseConfigFile();
 
 const config: Knex.Config = {
   client: 'pg',

--- a/src/cloud-cli/applications/deploy-app-code.ts
+++ b/src/cloud-cli/applications/deploy-app-code.ts
@@ -6,7 +6,7 @@ import FormData from "form-data";
 import { createGlobalLogger } from "../../telemetry/logs";
 import { getCloudCredentials } from "../utils";
 import { createDirectory } from "../../utils";
-import { ConfigFile, parseConfigFile, operonConfigFilePath } from "../../operon-runtime/config";
+import { ConfigFile, loadConfigFile, operonConfigFilePath } from "../../operon-runtime/config";
 
 const deployDirectoryName = "operon_deploy";
 
@@ -18,7 +18,7 @@ export async function deployAppCode(appName: string, host: string, port: string)
   try {
     createDirectory(deployDirectoryName);
 
-    const configFile: ConfigFile | undefined = parseConfigFile(operonConfigFilePath);
+    const configFile: ConfigFile | undefined = loadConfigFile(operonConfigFilePath);
     if (!configFile) {
       logger.error(`failed to parse ${operonConfigFilePath}`);
       return;

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -114,23 +114,26 @@ userdb
   .option('-a, --admin <admin>', 'Specify the admin user', 'postgres')
   .option('-W, --password <admin>', 'Specify the admin password', 'postgres')
   .option('-s, --sync', 'make synchronous call', false)
-  .action((async (dbname: string, options: { host: string, port: string, admin: string, password: string, sync: boolean }) => {
-    await createUserDb(options.host, options.port, dbname, options.admin, options.password, options.sync)
+  .action((async (dbname: string, options: { admin: string, password: string, sync: boolean }) => {
+    const { host, port }: { host: string, port: string } = applicationCommands.opts()
+    await createUserDb(host, port, dbname, options.admin, options.password, options.sync)
   }))
 
 userdb
   .command('status')
   .argument('<string>', 'database name')
-  .action((async (dbname: string, options: { host: string, port: string }) => {
-    await getUserDb(options.host, options.port, dbname)
+  .action((async (dbname: string) => {
+    const { host, port }: { host: string, port: string } = applicationCommands.opts()
+    await getUserDb(host, port, dbname)
   }))
 
 userdb
   .command('delete')
   .argument('<string>', 'database name')
   .option('-s, --sync', 'make synchronous call', false)
-  .action((async (dbname: string, options: { host: string, port: string, sync:boolean }) => {
-    await deleteUserDb(options.host, options.port, dbname, options.sync)
+  .action((async (dbname: string, options: { sync:boolean }) => {
+    const { host, port }: { host: string, port: string } = applicationCommands.opts()
+    await deleteUserDb(host, port, dbname, options.sync)
   }))
 
 program.parse(process.argv);

--- a/src/operon-runtime/cli.ts
+++ b/src/operon-runtime/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { operonConfigFilePath, buildConfigs } from "./config";
+import { operonConfigFilePath, parseConfigFile } from "./config";
 import { OperonRuntime, OperonRuntimeConfig } from "./runtime";
 import { Command } from 'commander';
 import { OperonConfig } from "../operon";
@@ -43,7 +43,7 @@ program
   .option('-c, --configfile <string>', 'Specify the Operon config file path', operonConfigFilePath)
   .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
   .action(async (options: OperonCLIStartOptions) => {
-    const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = buildConfigs(options);
+    const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(options);
     const runtime = new OperonRuntime(operonConfig, runtimeConfig);
     await runtime.init();
     runtime.startServer();

--- a/src/operon-runtime/config.ts
+++ b/src/operon-runtime/config.ts
@@ -46,7 +46,7 @@ function substituteEnvVars(content: string): string {
   });
 }
 
-export function parseConfigFile(configFilePath: string): ConfigFile | undefined {
+export function loadConfigFile(configFilePath: string): ConfigFile | undefined {
   let configFile: ConfigFile | undefined;
   try {
     const configFileContent = readFileSync(configFilePath);
@@ -65,9 +65,9 @@ export function parseConfigFile(configFilePath: string): ConfigFile | undefined 
  * Parse `operonConfigFilePath` and return OperonConfig and OperonRuntimeConfig
  * Considers OperonCLIStartOptions if provided, which takes precedence over config file
  * */
-export function buildConfigs(cliOptions?: OperonCLIStartOptions): [OperonConfig, OperonRuntimeConfig] {
+export function parseConfigFile(cliOptions?: OperonCLIStartOptions): [OperonConfig, OperonRuntimeConfig] {
   const configFilePath = cliOptions?.configfile ?? operonConfigFilePath;
-  const configFile: ConfigFile | undefined = parseConfigFile(configFilePath);
+  const configFile: ConfigFile | undefined = loadConfigFile(configFilePath);
   if (!configFile) {
     throw new OperonInitializationError(`Operon configuration file ${configFilePath} is empty`);
   }

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -7,7 +7,7 @@ import { OperonConfigKeyTypeError, OperonError } from "../error";
 import { InvokeFuncs } from "../httpServer/handler";
 import { OperonHttpServer } from "../httpServer/server";
 import { Operon, OperonConfig } from "../operon";
-import { operonConfigFilePath, buildConfigs } from "../operon-runtime/config";
+import { operonConfigFilePath, parseConfigFile } from "../operon-runtime/config";
 import { OperonTransaction } from "../transaction";
 import { OperonWorkflow, WorkflowHandle, WorkflowParams } from "../workflow";
 import { Http2ServerRequest, Http2ServerResponse } from "http2";
@@ -20,7 +20,7 @@ import { Client } from "pg";
  * Create a testing runtime. Warn: this function will drop the existing system DB and create a clean new one. Don't run tests against your production database!
  */
 export async function createTestingRuntime(userClasses: object[], configFilePath: string = operonConfigFilePath): Promise<OperonTestingRuntime> {
-  const [ operonConfig ] = buildConfigs({configfile: configFilePath});
+  const [ operonConfig ] = parseConfigFile({configfile: configFilePath});
 
   // Drop system database. Testing runtime always uses Postgres for local testing.
   const pgSystemClient = new Client({
@@ -84,7 +84,7 @@ export class OperonTestingRuntimeImpl implements OperonTestingRuntime {
    * This should be the first function call before any subsequent calls.
    */
   async init(userClasses: object[], testConfig?: OperonConfig, systemDB?: SystemDatabase) {
-    const operonConfig = testConfig ? [testConfig] : buildConfigs();
+    const operonConfig = testConfig ? [testConfig] : parseConfigFile();
     const operon = new Operon(operonConfig[0], systemDB);
     await operon.init(...userClasses);
     this.#server = new OperonHttpServer(operon);

--- a/tests/operon-runtime/config.test.ts
+++ b/tests/operon-runtime/config.test.ts
@@ -3,7 +3,7 @@
 import * as utils from "../../src/utils";
 import { UserDatabaseName } from "../../src/user_database";
 import { PoolConfig } from "pg";
-import { buildConfigs } from "../../src/operon-runtime/config";
+import { parseConfigFile } from "../../src/operon-runtime/config";
 import { OperonRuntimeConfig } from "../../src/operon-runtime/runtime";
 import { OperonConfigKeyTypeError, OperonInitializationError } from "../../src/error";
 import { Operon, OperonConfig } from "../../src/operon";
@@ -42,7 +42,7 @@ describe("operon-config", () => {
     test("Config is valid and is parsed as expected", () => {
       jest.spyOn(utils, "readFileSync").mockReturnValue(mockOperonConfigYamlString);
 
-      const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = buildConfigs(mockCLIOptions);
+      const [operonConfig, runtimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
 
       // Test pool config options
       const poolConfig: PoolConfig = operonConfig.poolConfig;
@@ -75,19 +75,19 @@ describe("operon-config", () => {
       jest.spyOn(utils, "readFileSync").mockImplementation(() => {
         throw new OperonInitializationError("some error");
       });
-      expect(() => buildConfigs(mockCLIOptions)).toThrow(OperonInitializationError);
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
     });
 
     test("config file is empty", () => {
       const mockConfigFile = "";
       jest.spyOn(utils, "readFileSync").mockReturnValue(JSON.stringify(mockConfigFile));
-      expect(() => buildConfigs(mockCLIOptions)).toThrow(OperonInitializationError);
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
     });
 
     test("config file is missing database config", () => {
       const mockConfigFile = { someOtherConfig: "some other config" };
       jest.spyOn(utils, "readFileSync").mockReturnValue(JSON.stringify(mockConfigFile));
-      expect(() => buildConfigs(mockCLIOptions)).toThrow(OperonInitializationError);
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
     });
 
     test("config file is missing database password", () => {
@@ -95,7 +95,7 @@ describe("operon-config", () => {
       delete process.env.PGPASSWORD;
       jest.spyOn(utils, "readFileSync").mockReturnValueOnce(mockOperonConfigYamlString);
       jest.spyOn(utils, "readFileSync").mockReturnValueOnce("SQL STATEMENTS");
-      expect(() => buildConfigs(mockCLIOptions)).toThrow(OperonInitializationError);
+      expect(() => parseConfigFile(mockCLIOptions)).toThrow(OperonInitializationError);
       process.env.PGPASSWORD = dbPassword;
     });
   });
@@ -110,7 +110,7 @@ describe("operon-config", () => {
     });
 
     test("getConfig returns the expected values", async () => {
-      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = buildConfigs(mockCLIOptions);
+      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const operon = new Operon(operonConfig);
       const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");
       // Config key exists
@@ -136,7 +136,7 @@ describe("operon-config", () => {
       `;
       jest.restoreAllMocks();
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockOperonConfigYamlString);
-      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = buildConfigs(mockCLIOptions);
+      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const operon = new Operon(operonConfig);
       const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");
       expect(ctx.getConfig<string>("payments_url", "default")).toBe("default");
@@ -146,7 +146,7 @@ describe("operon-config", () => {
     });
 
     test("getConfig throws when it finds a value of different type than the default", async () => {
-      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = buildConfigs(mockCLIOptions);
+      const [operonConfig, _operonRuntimeConfig]: [OperonConfig, OperonRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const operon = new Operon(operonConfig);
       const ctx: WorkflowContextImpl = new WorkflowContextImpl(operon, undefined, "testUUID", {}, "testContext");
       expect(() => ctx.getConfig<number>("payments_url", 1234)).toThrow(OperonConfigKeyTypeError);


### PR DESCRIPTION
A previous PR changed a function name used in demo apps' `knexfile`. Today we don't tag demo apps and their main branch has to be compatible with whatever version of the SDK they import.