### PR TITLE
add cloud CLI applications subcommand to update an application

### DIFF
--- a/src/cloud-cli/applications/index.ts
+++ b/src/cloud-cli/applications/index.ts
@@ -3,3 +3,4 @@ export { listApps } from './list-apps';
 export { deleteApp } from './delete-app';
 export { deployAppCode } from './deploy-app-code';
 export { getAppLogs } from './get-app-logs';
+export { updateApp } from './update-app';

--- a/src/cloud-cli/applications/index.ts
+++ b/src/cloud-cli/applications/index.ts
@@ -3,4 +3,4 @@ export { listApps } from './list-apps';
 export { deleteApp } from './delete-app';
 export { deployAppCode } from './deploy-app-code';
 export { getAppLogs } from './get-app-logs';
-export { updateApp } from './update-app';
+export { updateApp } from './update-app';

--- a/src/cloud-cli/applications/list-apps.ts
+++ b/src/cloud-cli/applications/list-apps.ts
@@ -25,7 +25,7 @@ export async function listApps(host: string, port: string) {
     const formattedData: Application[] = []
     for (const application of data) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      formattedData.push({ "Name": application.Name, "ID": application.ID, "Status": application.Status });
+      formattedData.push({ "Name": application.Name, "ID": application.ID, "Status": application.Status, "MaxVMs": application.MaxVMs });
     }
     console.log(JSON.stringify(formattedData));
   } catch (e) {

--- a/src/cloud-cli/applications/list-apps.ts
+++ b/src/cloud-cli/applications/list-apps.ts
@@ -1,12 +1,7 @@
 import axios from "axios";
 import { createGlobalLogger } from "../../telemetry/logs";
 import { getCloudCredentials } from "../utils";
-
-type Application = {
-  Name: string;
-  ID: string;
-  Status: string;
-};
+import { Application } from "./types";
 
 export async function listApps(host: string, port: string) {
   const logger = createGlobalLogger();
@@ -27,10 +22,12 @@ export async function listApps(host: string, port: string) {
       logger.info("no application found");
       return;
     }
+    const formattedData: Application[] = []
     for (const application of data) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      console.log({ Name: application.Name, ID: application.ID, Status: application.Status });
+      formattedData.push({ "Name": application.Name, "ID": application.ID, "Status": application.Status });
     }
+    console.log(JSON.stringify(formattedData));
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
       logger.error(`failed to list applications: ${e.response?.data}`);

--- a/src/cloud-cli/applications/types.ts
+++ b/src/cloud-cli/applications/types.ts
@@ -2,4 +2,5 @@ export type Application = {
   Name: string;
   ID: string;
   Status: string;
+  MaxVMs: string;
 };

--- a/src/cloud-cli/applications/types.ts
+++ b/src/cloud-cli/applications/types.ts
@@ -1,0 +1,5 @@
+export type Application = {
+  Name: string;
+  ID: string;
+  Status: string;
+};

--- a/src/cloud-cli/applications/update-app.ts
+++ b/src/cloud-cli/applications/update-app.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { createGlobalLogger } from "../../telemetry/logs";
 import { getCloudCredentials } from "../utils";
+import { Application } from "./types";
 
 export async function updateApp(appName: string, newName: string, host: string, port: string, machines: number) {
   const logger = createGlobalLogger();
@@ -8,7 +9,7 @@ export async function updateApp(appName: string, newName: string, host: string, 
   const bearerToken = "Bearer " + userCredentials.token;
 
   try {
-    const updatedName = newName ?? appName;
+    const updatedName = newName == '' ? appName : newName;
     logger.info(`Updating application ${appName} to name ${updatedName} and ${machines} machines`);
     const update = await axios.patch(
       `http://${host}:${port}/${userCredentials.userName}/application/${appName}`,
@@ -23,9 +24,9 @@ export async function updateApp(appName: string, newName: string, host: string, 
         },
       }
     );
-    const uuid = update.data as string;
-    logger.info(`Successfully updated: ${appName}`);
-    logger.info(`${appName} ID: ${uuid}`);
+    const application: Application = update.data as Application;
+    logger.info(`Successfully updated: ${application.Name}`);
+    console.log(JSON.stringify({ "Name": application.Name, "ID": application.ID, "Status": application.Status }));
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
       logger.error(`failed to register application ${appName}: ${e.response?.data}`);

--- a/src/cloud-cli/applications/update-app.ts
+++ b/src/cloud-cli/applications/update-app.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+import { createGlobalLogger } from "../../telemetry/logs";
+import { getCloudCredentials } from "../utils";
+
+export async function updateApp(appName: string, newName: string, host: string, port: string, machines: number) {
+  const logger = createGlobalLogger();
+  const userCredentials = getCloudCredentials();
+  const bearerToken = "Bearer " + userCredentials.token;
+
+  try {
+    const updatedName = newName ?? appName;
+    logger.info(`Updating application ${appName} to name ${updatedName} and ${machines} machines`);
+    const update = await axios.patch(
+      `http://${host}:${port}/${userCredentials.userName}/application/${appName}`,
+      {
+        name: updatedName,
+        max_vms: machines
+      },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: bearerToken,
+        },
+      }
+    );
+    const uuid = update.data as string;
+    logger.info(`Successfully updated: ${appName}`);
+    logger.info(`${appName} ID: ${uuid}`);
+  } catch (e) {
+    if (axios.isAxiosError(e) && e.response) {
+      logger.error(`failed to register application ${appName}: ${e.response?.data}`);
+    } else {
+      logger.error(`failed to register application ${appName}: ${(e as Error).message}`);
+    }
+  }
+}

--- a/src/cloud-cli/applications/update-app.ts
+++ b/src/cloud-cli/applications/update-app.ts
@@ -3,18 +3,17 @@ import { createGlobalLogger } from "../../telemetry/logs";
 import { getCloudCredentials } from "../utils";
 import { Application } from "./types";
 
-export async function updateApp(appName: string, newName: string, host: string, port: string, machines: number) {
+export async function updateApp(appName: string, host: string, port: string, machines: number) {
   const logger = createGlobalLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
   try {
-    const updatedName = newName == '' ? appName : newName;
-    logger.info(`Updating application ${appName} to name ${updatedName} and ${machines} machines`);
+    logger.info(`Updating application ${appName} to ${machines} machines`);
     const update = await axios.patch(
       `http://${host}:${port}/${userCredentials.userName}/application/${appName}`,
       {
-        name: updatedName,
+        name: appName,
         max_vms: machines
       },
       {

--- a/src/cloud-cli/applications/update-app.ts
+++ b/src/cloud-cli/applications/update-app.ts
@@ -26,12 +26,12 @@ export async function updateApp(appName: string, newName: string, host: string, 
     );
     const application: Application = update.data as Application;
     logger.info(`Successfully updated: ${application.Name}`);
-    console.log(JSON.stringify({ "Name": application.Name, "ID": application.ID, "Status": application.Status }));
+    console.log(JSON.stringify({ "Name": application.Name, "ID": application.ID, "Status": application.Status, "MaxVMs": application.MaxVMs }));
   } catch (e) {
     if (axios.isAxiosError(e) && e.response) {
-      logger.error(`failed to register application ${appName}: ${e.response?.data}`);
+      logger.error(`failed to update application ${appName}: ${e.response?.data}`);
     } else {
-      logger.error(`failed to register application ${appName}: ${(e as Error).message}`);
+      logger.error(`failed to update application ${appName}: ${(e as Error).message}`);
     }
   }
 }

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -74,10 +74,9 @@ applicationCommands
   .description('Update an application')
   .requiredOption('-n, --name <string>', 'Specify the app name')
   .requiredOption('-m, --machines <string>', 'Number of VMs to deploy')
-  .option('-N, --new-name <string>', 'New name for the application', '')
-  .action(async (options: { name: string, newName: string, machines: string }) => {
+  .action(async (options: { name: string, machines: string }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
-    await updateApp(options.name, options.newName, host, port, parseInt(options.machines));
+    await updateApp(options.name, host, port, parseInt(options.machines));
   });
 
 applicationCommands

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -129,7 +129,7 @@ userdb
   .argument('<string>', 'database name')
   .option('-a, --admin <string>', 'Specify the admin user', 'postgres')
   .option('-W, --password <string>', 'Specify the admin password', 'postgres')
-  .option('-s, --sync <bool>', 'make synchronous call', false)
+  .option('-s, --sync', 'make synchronous call', false)
   .action((async (dbname: string, options: { admin: string, password: string, sync: boolean }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await createUserDb(host, port, dbname, options.admin, options.password, options.sync)
@@ -146,8 +146,8 @@ userdb
 userdb
   .command('delete')
   .argument('<string>', 'database name')
-  .option('-s, --sync <bool>', 'make synchronous call', false)
-  .action((async (dbname: string, options: { sync:boolean }) => {
+  .option('-s, --sync', 'make synchronous call', false)
+  .action((async (dbname: string, options: { sync: boolean }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await deleteUserDb(host, port, dbname, options.sync)
   }))

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -2,6 +2,7 @@
 
 import {
   registerApp,
+  updateApp,
   listApps,
   deleteApp,
   deployAppCode,
@@ -64,6 +65,17 @@ applicationCommands
   .action(async (options: { name: string, machines: string }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await registerApp(options.name, host, port, parseInt(options.machines));
+  });
+
+applicationCommands
+  .command('update')
+  .description('Update an application')
+  .requiredOption('-n, --name', 'Specify the app name')
+  .requiredOption('-m, --machines', 'Number of VMs to deploy')
+  .option('-N, --new-name', 'New name for the application')
+  .action(async (options: { name: string, newName: string, machines: string }) => {
+    const { host, port }: { host: string, port: string } = applicationCommands.opts()
+    await updateApp(options.name, options.newName, host, port, parseInt(options.machines));
   });
 
 applicationCommands

--- a/src/cloud-cli/cli.ts
+++ b/src/cloud-cli/cli.ts
@@ -23,15 +23,14 @@ const packageJson = require('../../../package.json') as { version: string };
 program.
   version(packageJson.version);
 
-///////////////////////
-/* CLOUD DEPLOYMENT  */
-///////////////////////
+/////////////////////
+/* AUTHENTICATION  */
+/////////////////////
 
-/*** AUTHENTICATION ***/
 program
   .command('login')
   .description('Log in Operon cloud')
-  .requiredOption('-u, --userName <string>', 'User name for login', )
+  .requiredOption('-u, --userName <string>', 'User name for login')
   .action((options: { userName: string }) => {
     login(options.userName);
   });
@@ -39,9 +38,9 @@ program
 program
   .command('register')
   .description('Register a user and log in Operon cloud')
-  .requiredOption('-u, --userName <string>', 'User name', )
+  .requiredOption('-u, --userName <string>', 'User name')
   .option('-h, --host <string>', 'Specify the host', DEFAULT_HOST)
-  .option('-p, --port <port>', 'Specify the port', DEFAULT_PORT)
+  .option('-p, --port <string>', 'Specify the port', DEFAULT_PORT)
   .action(async (options: { userName: string, host: string, port: string }) => {
     const success = await registerUser(options.userName, options.host, options.port);
     // Then, log in as the user.
@@ -50,18 +49,21 @@ program
     }
   });
 
-/*** APPLICATIONS MANAGEMENT ***/
+/////////////////////////////
+/* APPLICATIONS MANAGEMENT */
+/////////////////////////////
+
 const applicationCommands = program
   .command('applications')
   .description('Manage your DBOS applications')
   .option('-h, --host <string>', 'Specify the host', DEFAULT_HOST)
-  .option('-p, --port <port>', 'Specify the port', DEFAULT_PORT)
+  .option('-p, --port <string>', 'Specify the port', DEFAULT_PORT)
 
 applicationCommands
   .command('register')
   .description('Register a new application')
   .requiredOption('-n, --name <string>', 'Specify the app name')
-  .option('-m, --machines <number>', 'Number of VMs to deploy', '1')
+  .option('-m, --machines <string>', 'Number of VMs to deploy', '1')
   .action(async (options: { name: string, machines: string }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await registerApp(options.name, host, port, parseInt(options.machines));
@@ -70,9 +72,9 @@ applicationCommands
 applicationCommands
   .command('update')
   .description('Update an application')
-  .requiredOption('-n, --name', 'Specify the app name')
-  .requiredOption('-m, --machines', 'Number of VMs to deploy')
-  .option('-N, --new-name', 'New name for the application')
+  .requiredOption('-n, --name <string>', 'Specify the app name')
+  .requiredOption('-m, --machines <string>', 'Number of VMs to deploy')
+  .option('-N, --new-name <string>', 'New name for the application', '')
   .action(async (options: { name: string, newName: string, machines: string }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await updateApp(options.name, options.newName, host, port, parseInt(options.machines));
@@ -113,19 +115,22 @@ applicationCommands
     await getAppLogs(options.name, host, port);
   });
 
-/*** USER DATABASE MANAGEMENT ***/
+//////////////////////////////
+/* USER DATABASE MANAGEMENT */
+//////////////////////////////
+
 const userdb = program
   .command('userdb')
   .description('Manage your databases')
   .option('-h, --host <string>', 'Specify the host', DEFAULT_HOST)
-  .option('-p, --port <port>', 'Specify the port', DEFAULT_PORT)
+  .option('-p, --port <string>', 'Specify the port', DEFAULT_PORT)
 
 userdb
   .command('create')
   .argument('<string>', 'database name')
-  .option('-a, --admin <admin>', 'Specify the admin user', 'postgres')
-  .option('-W, --password <admin>', 'Specify the admin password', 'postgres')
-  .option('-s, --sync', 'make synchronous call', false)
+  .option('-a, --admin <string>', 'Specify the admin user', 'postgres')
+  .option('-W, --password <string>', 'Specify the admin password', 'postgres')
+  .option('-s, --sync <bool>', 'make synchronous call', false)
   .action((async (dbname: string, options: { admin: string, password: string, sync: boolean }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await createUserDb(host, port, dbname, options.admin, options.password, options.sync)
@@ -142,7 +147,7 @@ userdb
 userdb
   .command('delete')
   .argument('<string>', 'database name')
-  .option('-s, --sync', 'make synchronous call', false)
+  .option('-s, --sync <bool>', 'make synchronous call', false)
   .action((async (dbname: string, options: { sync:boolean }) => {
     const { host, port }: { host: string, port: string } = applicationCommands.opts()
     await deleteUserDb(host, port, dbname, options.sync)

--- a/src/operon-runtime/config.ts
+++ b/src/operon-runtime/config.ts
@@ -50,7 +50,7 @@ export function loadConfigFile(configFilePath: string): ConfigFile | undefined {
   let configFile: ConfigFile | undefined;
   try {
     const configFileContent = readFileSync(configFilePath);
-    const interpolatedConfig = substituteEnvVars(configFileContent);
+    const interpolatedConfig = substituteEnvVars(configFileContent as string);
     configFile = YAML.parse(interpolatedConfig) as ConfigFile;
   } catch (e) {
     if (e instanceof Error) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import fs from "fs";
  * - the file does not exist
  * - the file is not a valid file
  **/
-export function readFileSync(path: string): string {
+export function readFileSync(path: string, encoding: BufferEncoding = "utf8"): string | Buffer {
   // First, check the file
   fs.stat(path, (error: NodeJS.ErrnoException | null, stats: fs.Stats) => {
     if (error) {
@@ -17,7 +17,7 @@ export function readFileSync(path: string): string {
   });
 
   // Then, read its content
-  const fileContent: string = fs.readFileSync(path, "utf8");
+  const fileContent: string = fs.readFileSync(path, { encoding } );
   return fileContent;
 }
 


### PR DESCRIPTION
A subcommand to update applications.

For now, does the most simple thing: ask users to always provide the full intent of the app record, i.e., provide a name and max_vms.  For now, only `max_vms` can be updated. Updating the application name require more uplifting in the backend, which we should not do now.