### PR TITLE
Capture transaction info & Handle workflow exceptions

### DIFF
--- a/examples/hello/start_postgres_docker.sh
+++ b/examples/hello/start_postgres_docker.sh
@@ -6,18 +6,8 @@ if [[ -z "${PGPASSWORD}" ]]; then
   exit 1
 fi
 
-SCRIPT_DIR=$(dirname $(readlink -f $0))
-# Enter the root dir of the example app.
-cd ${SCRIPT_DIR}/
-
 # Start Postgres in a local Docker container
-docker run --rm --name=operon-db --env=POSTGRES_PASSWORD=${PGPASSWORD} --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 5432:5432 -d postgres:15.4 -c wal_level=logical
-
-# Install wal2json
-docker exec operon-db apt-get update
-docker exec operon-db apt-get install postgresql-15-wal2json -y
-docker exec operon-db sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
-docker restart operon-db
+docker run --rm --name=operon-db --env=POSTGRES_PASSWORD=${PGPASSWORD} --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 5432:5432 -d postgres:15.4
 
 # Wait for PostgreSQL to start
 echo "Waiting for PostgreSQL to start..."
@@ -31,15 +21,3 @@ done
 
 # Create a database in Postgres.
 docker exec operon-db psql -U postgres -c "CREATE DATABASE hello;"
-
-npx knex migrate:latest
-
-# create WAL reader slot
-docker exec operon-db psql -U postgres -d hello -c "SELECT * FROM pg_create_logical_replication_slot('operon_prov', 'wal2json');"
-
-# create a database in Postgres for the provenance data
-docker exec operon-db psql -U postgres -c "CREATE DATABASE hello_prov;"
-
-# eventually, prov table scehma will be generated from cloud deploy information
-# manually add the prov table schema for now
-docker exec operon-db psql -U postgres -d hello_prov -c "CREATE TABLE operon_hello(name text NOT NULL, greet_count integer DEFAULT 0, begin_xid xid8 NOT NULL, end_xid xid8 NULL);"

--- a/examples/hello/start_postgres_docker.sh
+++ b/examples/hello/start_postgres_docker.sh
@@ -6,8 +6,18 @@ if [[ -z "${PGPASSWORD}" ]]; then
   exit 1
 fi
 
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+# Enter the root dir of the example app.
+cd ${SCRIPT_DIR}/
+
 # Start Postgres in a local Docker container
-docker run --rm --name=operon-db --env=POSTGRES_PASSWORD=${PGPASSWORD} --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 5432:5432 -d postgres:15.4
+docker run --rm --name=operon-db --env=POSTGRES_PASSWORD=${PGPASSWORD} --env=PGDATA=/var/lib/postgresql/data --volume=/var/lib/postgresql/data -p 5432:5432 -d postgres:15.4 -c wal_level=logical
+
+# Install wal2json
+docker exec operon-db apt-get update
+docker exec operon-db apt-get install postgresql-15-wal2json -y
+docker exec operon-db sh -c 'echo "wal_level=logical" >> /var/lib/postgresql/data/postgresql.conf'
+docker restart operon-db
 
 # Wait for PostgreSQL to start
 echo "Waiting for PostgreSQL to start..."
@@ -21,3 +31,15 @@ done
 
 # Create a database in Postgres.
 docker exec operon-db psql -U postgres -c "CREATE DATABASE hello;"
+
+npx knex migrate:latest
+
+# create WAL reader slot
+docker exec operon-db psql -U postgres -d hello -c "SELECT * FROM pg_create_logical_replication_slot('operon_prov', 'wal2json');"
+
+# create a database in Postgres for the provenance data
+docker exec operon-db psql -U postgres -c "CREATE DATABASE hello_prov;"
+
+# eventually, prov table scehma will be generated from cloud deploy information
+# manually add the prov table schema for now
+docker exec operon-db psql -U postgres -d hello_prov -c "CREATE TABLE operon_hello(name text NOT NULL, greet_count integer DEFAULT 0, begin_xid xid8 NOT NULL, end_xid xid8 NULL);"

--- a/schemas/user_db_schema.ts
+++ b/schemas/user_db_schema.ts
@@ -3,6 +3,8 @@ export interface transaction_outputs {
   function_id: number;
   output: string;
   error: string;
+  txn_id: string;
+  txn_snapshot: string;
 }
 
 export const createUserDBSchema = `CREATE SCHEMA IF NOT EXISTS operon;`;
@@ -13,6 +15,8 @@ export const userDBSchema = `
     function_id INT NOT NULL,
     output TEXT,
     error TEXT,
+    txn_id TEXT,
+    txn_snapshot TEXT,
     PRIMARY KEY (workflow_uuid, function_id)
   );
 `;

--- a/schemas/user_db_schema.ts
+++ b/schemas/user_db_schema.ts
@@ -16,7 +16,7 @@ export const userDBSchema = `
     output TEXT,
     error TEXT,
     txn_id TEXT,
-    txn_snapshot TEXT,
+    txn_snapshot TEXT NOT NULL,
     PRIMARY KEY (workflow_uuid, function_id)
   );
 `;

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -80,7 +80,6 @@ export class OperonHttpServer {
       const executorIDs = koaCtxt.request.body as string[];
       operon.logger.info("Recovering workflows for executors: " + executorIDs.toString());
       const recoverHandles = await operon.recoverPendingWorkflows(executorIDs);
-      operon.recoveryWorkflowHandles.push(...recoverHandles);
 
       // Return a list of workflowUUIDs being recovered.
       koaCtxt.body = await Promise.allSettled(recoverHandles.map((i) => i.getWorkflowUUID())).then((results) =>

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -86,7 +86,7 @@ export class Operon {
   readonly topicConfigMap: Map<string, string[]> = new Map();
   readonly registeredOperations: Array<OperonMethodRegistrationBase> = [];
   readonly initialEpochTimeMs: number;
-  readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map();  // Map from workflowUUID to workflow handle.
+  readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map();  // Map from workflowUUID to workflow promise.
 
   readonly telemetryCollector: TelemetryCollector;
   readonly flushBufferIntervalMs: number = 1000;
@@ -350,7 +350,7 @@ export class Operon {
         this.logger.debug("Captured error in awaitWorkflowPromise: " + error);
       })
       .finally(() => {
-        // Remove itself from pending workflow handles.
+        // Remove itself from pending workflow map.
         this.pendingWorkflowMap.delete(workflowUUID);
       });
     this.pendingWorkflowMap.set(workflowUUID, awaitWorkflowPromise);

--- a/src/operon.ts
+++ b/src/operon.ts
@@ -86,7 +86,7 @@ export class Operon {
   readonly topicConfigMap: Map<string, string[]> = new Map();
   readonly registeredOperations: Array<OperonMethodRegistrationBase> = [];
   readonly initialEpochTimeMs: number;
-  readonly pendingWorkflowHandles: Map<string, Promise<unknown>> = new Map();  // Map from workflowUUID to workflow handle.
+  readonly pendingWorkflowMap: Map<string, Promise<unknown>> = new Map();  // Map from workflowUUID to workflow handle.
 
   readonly telemetryCollector: TelemetryCollector;
   readonly flushBufferIntervalMs: number = 1000;
@@ -247,9 +247,9 @@ export class Operon {
   }
 
   async destroy() {
-    if (this.pendingWorkflowHandles.size > 0) {
+    if (this.pendingWorkflowMap.size > 0) {
       this.logger.info("Waiting for pending workflows to finish.");
-      await Promise.allSettled(this.pendingWorkflowHandles.values());
+      await Promise.allSettled(this.pendingWorkflowMap.values());
     }
     clearInterval(this.flushBufferID);
     await this.flushWorkflowStatusBuffer();
@@ -351,9 +351,9 @@ export class Operon {
       })
       .finally(() => {
         // Remove itself from pending workflow handles.
-        this.pendingWorkflowHandles.delete(workflowUUID);
+        this.pendingWorkflowMap.delete(workflowUUID);
       });
-    this.pendingWorkflowHandles.set(workflowUUID, awaitWorkflowPromise);
+    this.pendingWorkflowMap.set(workflowUUID, awaitWorkflowPromise);
 
     // Return the normal handle that doesn't capture errors.
     return new InvokedHandle(this.systemDatabase, workflowPromise, workflowUUID, wf.name, callerUUID, callerFunctionID);

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -134,9 +134,10 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
     funcIDs.sort();
     try {
       for (const funcID of funcIDs) {
+        // Capture output and also transaction snapshot information.
         await this.#operon.userDatabase.queryWithClient(
           client,
-          "INSERT INTO operon.transaction_outputs (workflow_uuid, function_id, output, error) VALUES ($1, $2, $3, $4);",
+          "INSERT INTO operon.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot) VALUES ($1, $2, $3, $4, (select pg_current_xact_id_if_assigned()), (select pg_current_snapshot()));",
           this.workflowUUID,
           funcID,
           JSON.stringify(this.resultBuffer.get(funcID)),
@@ -165,7 +166,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
    */
   async recordGuardedOutput<R>(client: UserDatabaseClient, funcID: number, output: R): Promise<void> {
     const serialOutput = JSON.stringify(output);
-    await this.#operon.userDatabase.queryWithClient(client, "UPDATE operon.transaction_outputs SET output=$1 WHERE workflow_uuid=$2 AND function_id=$3;", serialOutput, this.workflowUUID, funcID);
+    await this.#operon.userDatabase.queryWithClient(client, "UPDATE operon.transaction_outputs SET output=$1, txn_id=(select pg_current_xact_id_if_assigned()) WHERE workflow_uuid=$2 AND function_id=$3;", serialOutput, this.workflowUUID, funcID);
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -137,11 +137,12 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
         // Capture output and also transaction snapshot information.
         await this.#operon.userDatabase.queryWithClient(
           client,
-          "INSERT INTO operon.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot) VALUES ($1, $2, $3, $4, (select pg_current_xact_id_if_assigned()), (select pg_current_snapshot()));",
+          "INSERT INTO operon.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot) VALUES ($1, $2, $3, $4, $5, (select pg_current_snapshot()));",
           this.workflowUUID,
           funcID,
           JSON.stringify(this.resultBuffer.get(funcID)),
-          JSON.stringify(null)
+          JSON.stringify(null),
+          JSON.stringify(null),  // Initially, no txn_id because no queries executed.
         );
       }
     } catch (error) {


### PR DESCRIPTION
This PR implements two things:
1. Record transaction ID (if the transaction contains writes) and transaction snapshot information in `operon.transaction_outputs` table. This table will be exported through WAL to our provenance database.
2. Fix a bug where Operon may crash due to uncaught workflow exceptions. We now keep track of pending workflows using a `pendingWorkflowMap` map. Each workflow adds itself when being invoked and deletes itself from the map when it completes, while catching errors thrown by its executions.