### PR TITLE
Fix Error-Handling Issue

### DIFF
--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -129,7 +129,7 @@ export class PGNodeUserDatabase implements UserDatabase {
       return false;
     }
     const pge = this.getPostgresErrorCode(error);
-    return pge === "40001" || pge === "23505";
+    return pge === "23505";
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -229,7 +229,7 @@ export class PrismaUserDatabase implements UserDatabase {
 
   isKeyConflictError(error: unknown): boolean {
     const pge = this.getPostgresErrorCode(error);
-    return pge === "40001" || pge === "23505";
+    return pge === "23505";
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -336,7 +336,7 @@ export class TypeORMDatabase implements UserDatabase {
 
   isKeyConflictError(error: unknown): boolean {
     const pge = this.getPostgresErrorCode(error);
-    return pge === "40001" || pge === "23505";
+    return pge === "23505";
   }
 
   async createSchema(): Promise<void> {
@@ -423,7 +423,7 @@ export class KnexUserDatabase implements UserDatabase {
 
   isKeyConflictError(error: unknown): boolean {
     const pge = this.getPostgresErrorCode(error);
-    return pge === "40001" || pge === "23505";
+    return pge === "23505";
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -128,6 +128,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
   /**
    * Write all entries in the workflow result buffer to the database.
    * If it encounters a primary key or serialization error, this indicates a concurrent execution with the same UUID, so throw an OperonError.
+   * TODO: All calls to flushResultBuffer must be retried on serialization error.
    */
   async flushResultBuffer(client: UserDatabaseClient): Promise<void> {
     const funcIDs = Array.from(this.resultBuffer.keys());

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Operon, OperonNull, operonNull } from "./operon";
 import { transaction_outputs } from "../schemas/user_db_schema";
-import { OperonTransaction, TransactionContext, TransactionContextImpl } from "./transaction";
+import { IsolationLevel, OperonTransaction, TransactionContext, TransactionContextImpl } from "./transaction";
 import { OperonCommunicator, CommunicatorContext, CommunicatorContextImpl } from "./communicator";
 import { OperonError, OperonNotRegisteredError, OperonWorkflowConflictUUIDError } from "./error";
 import { serializeError, deserializeError } from "serialize-error";
@@ -127,8 +127,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
 
   /**
    * Write all entries in the workflow result buffer to the database.
-   * If it encounters a primary key or serialization error, this indicates a concurrent execution with the same UUID, so throw an OperonError.
-   * TODO: All calls to flushResultBuffer must be retried on serialization error.
+   * If it encounters a primary key error, this indicates a concurrent execution with the same UUID, so throw an OperonError.
    */
   async flushResultBuffer(client: UserDatabaseClient): Promise<void> {
     const funcIDs = Array.from(this.resultBuffer.keys());
@@ -278,7 +277,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
         await this.#operon.userDatabase.transaction(async (client: UserDatabaseClient) => {
           await this.flushResultBuffer(client);
           await this.recordGuardedError(client, funcId, e);
-        }, {});
+        }, { isolationLevel: IsolationLevel.ReadCommitted });
         this.resultBuffer.clear();
         span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
         throw err;
@@ -318,7 +317,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
 
     await this.#operon.userDatabase.transaction(async (client: UserDatabaseClient) => {
       await this.flushResultBuffer(client);
-    }, {});
+    }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
     // Check if this execution previously happened, returning its original result if it did.
@@ -386,7 +385,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
 
     await this.#operon.userDatabase.transaction(async (client: UserDatabaseClient) => {
       await this.flushResultBuffer(client);
-    }, {});
+    }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
     await this.#operon.systemDatabase.send(this.workflowUUID, functionID, destinationUUID, message, topic);
@@ -402,7 +401,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
 
     await this.#operon.userDatabase.transaction(async (client: UserDatabaseClient) => {
       await this.flushResultBuffer(client);
-    }, {});
+    }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
     return this.#operon.systemDatabase.recv(this.workflowUUID, functionID, topic, timeoutSeconds);
@@ -417,7 +416,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
 
     await this.#operon.userDatabase.transaction(async (client: UserDatabaseClient) => {
       await this.flushResultBuffer(client);
-    }, {});
+    }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
     await this.#operon.systemDatabase.setEvent(this.workflowUUID, functionID, key, value);


### PR DESCRIPTION
Fixed an issue where some serialization errors would be converted to WorkflowConflictUUID errors and not retried, instead leaving the workflow stuck forever waiting for the fictitious other workflow with the same UUID.