### PR TITLE
Fix Snapshot Capture

### DIFF
--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -383,7 +383,7 @@ export class KnexUserDatabase implements UserDatabase {
       async (transactionClient: Knex.Transaction) => {
         return await transactionFunction(transactionClient, ...args);
       },
-      { isolationLevel: isolationLevel }
+      { isolationLevel: isolationLevel, readOnly: config.readOnly ?? false }
     );
     return result;
   }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -125,6 +125,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
     );
 
     if (rows.length === 0 || rows.length > 2) {
+      this.logger.error("Unexpected! This should never happen. Returned rows: " + rows.toString());
       throw new OperonError("This should never happen. Returned rows: " + rows.toString());
     }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -142,6 +142,7 @@ export class WorkflowContextImpl extends OperonContextImpl implements WorkflowCo
       // Find the row with recorded output.
       rows.forEach((row) => {
         if (row.recorded) {
+          this.logger.debug("Found recorded output. " + JSON.stringify(row))
           if (JSON.parse(row.error) !== null) {
             throw deserializeError(JSON.parse(row.error));
           } else {


### PR DESCRIPTION
This PR fixes the snapshot capturing for read-only transactions and several small bugs.

1. We should capture snapshot information when we first start the transaction not when we flush the result buffer (for read-only transactions, this happens in a different following transaction).
   - This PR aims to capture snapshot in a single roundtrip to the DB (because RDS roundtrips are slow), therefore we piggyback this check with the check recorded output query.
   - Added a test for snapshot information capture. 
3. We eliminated an unnecessary roundtrip to retrieve transaction ID (`pg_current_xact_id()` also consumes transaction ID which is bad).
4. We also fixed a small issue where read-only knex transactions are not correctly marked as read-only.
